### PR TITLE
Replaces the CouchDB port with default API port

### DIFF
--- a/src/bin/medic-conf.js
+++ b/src/bin/medic-conf.js
@@ -50,7 +50,9 @@ switch(args[0]) {
       if(!process.env.COUCH_URL.match(/localhost/)) {
         throw new Error(`You asked to configure a local instance, but the COUCH_URL env var is set to '${process.env.COUCH_URL}'.  This may be a remote server.`);
       }
-      instanceUrl = process.env.COUCH_URL.replace(/\/medic$/, '');
+      instanceUrl = process.env.COUCH_URL
+        .replace(/\/medic$/, '') // strip off the database
+        .replace(/:5984/, ':5988'); // use api port instead of couchdb
       info('Using instance URL from COUCH_URL environment variable.');
     } else {
       instanceUrl = 'http://admin:pass@localhost:5988';


### PR DESCRIPTION
For importing/exporting settings we now use an API endpoint rather
than a couchapp route so we need to use the API port. This makes the
environment variable implementation equivalent to the default --local
and remote implementations which already use the API port.

medic/medic-conf#75