### PR TITLE
Add attribute to hide inputs section

### DIFF
--- a/src/lib/convert-forms.js
+++ b/src/lib/convert-forms.js
@@ -77,6 +77,7 @@ const fixXml = (path, hiddenFields, transformer, enketo) => {
       // The following copies behaviour from old bash scripts, and will create a
       // second <meta> element if one already existed.  We may want to actually
       // merge the two instead.
+      .replace(/<inputs tag="hidden">/, META_XML_SECTION)
       .replace(/<inputs>/, META_XML_SECTION)
 
       // XLSForm does not allow converting a field without a label, so we use
@@ -123,7 +124,7 @@ function executableAvailable() {
   }
 }
 
-const META_XML_SECTION = `<inputs>
+const META_XML_SECTION = `<inputs tag="hidden">
             <meta>
               <location>
                 <lat/>


### PR DESCRIPTION
This is redundant because the inputs are already not shown on the webapp side, but added for consistency with other hidden groups.

For https://github.com/medic/medic-projects/issues/4952