### PR TITLE
attempt at fixing contact-based tasks

### DIFF
--- a/src/nools/lib.js
+++ b/src/nools/lib.js
@@ -79,6 +79,8 @@ function emitTasksForSchedule(c, schedule, r) {
         } else {
           dueDate = new Date(Utils.addDate(new Date(r.reported_date), event.days));
         }
+      } else if(c && !r && event.dueDate){
+          dueDate = event.dueDate(c.contact, event, scheduledTaskIdx);
       }
 
       if (!Utils.isTimely(dueDate, event)) {


### PR DESCRIPTION
This is broken out of the box since we are setting the dueDate only is a report is non-empty. For contact-based tasks, the report object will always be unset.

Not sure if this change breaks anything. We at least get the task to show on the task bar BUT, clicking on it leads up to the task summary page rather than the form.