### PR TITLE
Overwrite custom properties

### DIFF
--- a/src/fn/upload-custom-translations.js
+++ b/src/fn/upload-custom-translations.js
@@ -25,7 +25,7 @@ module.exports = (projectDir, couchUrl) => {
               if(e.status === 404) return newDocFor(fileName);
               else throw e;
             })
-            .then(doc => mergeProperties(doc, translations))
+            .then(doc => overwriteProperties(doc, translations))
             .then(doc => db.put(doc));
         }));
     });
@@ -42,12 +42,8 @@ function propertiesAsObject(path) {
   return vals;
 }
 
-function mergeProperties(doc, props) {
-  if(!doc.values) doc.values = {};
-
-  for(const k in props) {
-    if(props.hasOwnProperty(k)) doc.values[k] = props[k];
-  }
+function overwriteProperties(doc, props) {
+  doc.custom = props;
 
   return doc;
 }

--- a/src/fn/upload-custom-translations.js
+++ b/src/fn/upload-custom-translations.js
@@ -43,7 +43,20 @@ function propertiesAsObject(path) {
 }
 
 function overwriteProperties(doc, props) {
-  doc.custom = props;
+  if(doc.default) {
+    // 3.4.0 translation structure
+    doc.custom = props;
+  } else {
+    // obsolete doc structure
+    if(!doc.values) {
+      doc.values = {};
+    }
+    for(const k in props) {
+      if(props.hasOwnProperty(k)) {
+        doc.values[k] = props[k];
+      }
+    }
+  }
 
   return doc;
 }

--- a/test/fn/upload-custom-translations.spec.js
+++ b/test/fn/upload-custom-translations.spec.js
@@ -44,7 +44,7 @@ describe('upload-custom-translations', () => {
       .then(doc => {
         assert.equal(doc.code, lang);
         assert.equal(doc.type, 'translations');
-        assert.deepEqual(doc.custom, expectedTranslations);
+        assert.deepEqual(doc.custom || doc.values, expectedTranslations);
       });
   }
 });

--- a/test/fn/upload-custom-translations.spec.js
+++ b/test/fn/upload-custom-translations.spec.js
@@ -44,7 +44,7 @@ describe('upload-custom-translations', () => {
       .then(doc => {
         assert.equal(doc.code, lang);
         assert.equal(doc.type, 'translations');
-        assert.deepEqual(doc.values, expectedTranslations);
+        assert.deepEqual(doc.custom, expectedTranslations);
       });
   }
 });


### PR DESCRIPTION
Changed the structure of translations to enable full overwrite in order to reflect addition/deletion of translation keys.
Now, the structure of the translation doc is: `{....., "custom":{...}, "default":{...}}`
* `"custom":{...}` has the custom translations uploaded via `medic-conf`
* `"default":{...}` has the default translations

Related `medic-webapp` PR: https://github.com/medic/medic-webapp/pull/4970

medic/medic-webapp#3128