### PR TITLE
Allow medic conf to progress even when it can not get the latest update data

### DIFF
--- a/src/lib/check-for-updates.js
+++ b/src/lib/check-for-updates.js
@@ -6,18 +6,18 @@ module.exports = (options) => {
   const current = require('../../package').version;
   info(`Current version: ${current}.  Checking NPM for updates…`);
 
-  if(!options) options = {};
+  if (!options) options = {};
 
   return request
     .get('https://registry.npmjs.org/medic-conf')
-      .then(res => {
-	const json = JSON.parse(res);
-	const latest = json['dist-tags'].latest;
+    .then(res => {
+      const json = JSON.parse(res);
+      const latest = json['dist-tags'].latest;
 
-	if(latest === current) {
-	  info('You are already on the latest version :¬)');
-	} else {
-	  warn(`New version available!
+      if (latest === current) {
+        info('You are already on the latest version :¬)');
+      } else {
+        warn(`New version available!
 
 	  ${current} -> ${latest}
 
@@ -25,13 +25,14 @@ module.exports = (options) => {
 
 	  npm install -g medic-conf
   `);
-	}
-      })
-      .catch(err => {
-	if(options.nonFatal && err.cause && err.cause.code === 'ENOTFOUND') {
-	  warn('Could not check NPM for updates.  You may be offline.');
-	} else {
-    warn(`Could not check NPM for updates. Error:${err.message}`);
-  } })
-      ;
+      }
+    })
+    .catch(err => {
+      if (options.nonFatal && err.cause && err.cause.code === 'ENOTFOUND') {
+        warn('Could not check NPM for updates.  You may be offline.');
+      } else {
+        warn(`Could not check NPM for updates. Error:${err.message}`);
+      }
+    })
+    ;
 };

--- a/src/lib/check-for-updates.js
+++ b/src/lib/check-for-updates.js
@@ -31,7 +31,7 @@ module.exports = (options) => {
       if (options.nonFatal && err.cause && err.cause.code === 'ENOTFOUND') {
         warn('Could not check NPM for updates.  You may be offline.');
       } else {
-        warn(`Could not check NPM for updates. Error:${err.message}`);
+        warn(`Could not check NPM for updates. Error: ${err.message}`);
       }
     })
     ;

--- a/src/lib/check-for-updates.js
+++ b/src/lib/check-for-updates.js
@@ -30,7 +30,8 @@ module.exports = (options) => {
       .catch(err => {
 	if(options.nonFatal && err.cause && err.cause.code === 'ENOTFOUND') {
 	  warn('Could not check NPM for updates.  You may be offline.');
-	} else throw err;
-      })
+	} else {
+    warn(`Could not check NPM for updates. Error:${err.message}`);
+  } })
       ;
 };


### PR DESCRIPTION
Medic-conf was choking and could not progress if it got an error for example this one below
`ERROR SyntaxError: Unexpected end of JSON input at JSON.parse (<anonymous>) at request.get.then.res (/Users/kennethatria/.nvm/versions/node/v8.11.0/lib/node_modules/medic-conf/src/lib/check-for-updates.js:14:20) at <anonymous> at process._tickCallback (internal/process/next_tick.js:188:7)`

So I created a minor fix. 