### PR TITLE
New db argument supports uploading to a different database

### DIFF
--- a/src/bin/medic-conf.js
+++ b/src/bin/medic-conf.js
@@ -16,6 +16,7 @@ const warn = require('../lib/log').warn;
 
 let args = process.argv.slice(2);
 const shift = n => args = args.slice(n || 1);
+let dbName = 'medic';
 
 if(!args.length) {
   return checkForUpdates({ nonFatal:true })
@@ -84,8 +85,13 @@ if(args[0] === '--no-check') {
   shift();
 }
 
+if (args[0] === '--db') {
+  dbName = args[1];
+  shift(2);
+}
+
 const projectName = fs.path.basename(fs.path.resolve('.'));
-const couchUrl = instanceUrl && `${instanceUrl}/medic`;
+const couchUrl = instanceUrl && `${instanceUrl}/${dbName}`;
 
 if(instanceUrl) {
   if(instanceUrl.match('/medic$')) warn('Supplied URL ends in "/medic".  This is probably incorrect.');

--- a/src/cli/usage.js
+++ b/src/cli/usage.js
@@ -50,6 +50,12 @@ ${bold('OPTIONS')}
 
 	--changelog
 		Display application changelog.
+
+	--no-check
+		Do not check for medic-conf updates.
+	
+	--db <database name>
+		Upload to a specific database. Defaults to ${bold('medic')}.
 `);
 
   process.exit(exitCode);


### PR DESCRIPTION
I have multiple databases locally with very different user data and configurations. I would personally find it very useful to support multiple database names here.  Alternatively, I could pull the database name from the COUCH_URL.