### PR TITLE
Converge target emit code for reports and contacts to shared function

### DIFF
--- a/src/nools/lib.js
+++ b/src/nools/lib.js
@@ -141,7 +141,7 @@ function emitTasksForSchedule(c, schedule, r) {
 function emitTargetFor(targetConfig, c, r) {
   var isEmittingForReport = !!r;
   if (!c.contact) return;
-  const appliesToKey = isEmittingForReport ? r.form : c.contact.type;
+  var appliesToKey = isEmittingForReport ? r.form : c.contact.type;
   if (targetConfig.appliesToType && targetConfig.appliesToType.indexOf(appliesToKey) < 0) return;
   if (targetConfig.appliesIf && !targetConfig.appliesIf(c, r)) return;
 

--- a/src/nools/lib.js
+++ b/src/nools/lib.js
@@ -3,13 +3,13 @@ for(idx1=0; idx1<targets.length; ++idx1) {
   switch(target.appliesTo) {
     case 'contacts':
       if(c.contact && target.appliesToType.indexOf(c.contact.type) !== -1) {
-        emitContactBasedTargetFor(c, target);
+        emitTargetFor(target, c);
       }
       break;
     case 'reports':
       for(idx2=0; idx2<c.reports.length; ++idx2) {
         r = c.reports[idx2];
-        emitReportBasedTargetFor(c, r, target);
+        emitTargetFor(target, c, r);
       }
       break;
     default:
@@ -140,40 +140,34 @@ function emitTasksForSchedule(c, schedule, r) {
   }
 }
 
-function emitContactBasedTargetFor(c, targetConfig) {
-  if(targetConfig.appliesIf && !targetConfig.appliesIf(c)) return;
+function emitTargetFor(targetConfig, c, r) {
+  var isEmittingForReport = !!r;
+  if(targetConfig.appliesIf && !targetConfig.appliesIf(c, r)) return;
 
-  var pass = !targetConfig.passesIf || !!targetConfig.passesIf(c);
+  var pass = !targetConfig.passesIf || !!targetConfig.passesIf(c, r);
+  var instanceDoc = isEmittingForReport ? r : c.contact;
+  var instance = createTargetInstance(targetConfig.id, instanceDoc, pass);
 
-  var instance = createTargetInstance(targetConfig.id, c.contact, pass);
+  if (isEmittingForReport) {
+    instance._id = (targetConfig.idType === 'report' ? r && r._id : c.contact._id) + '~' + targetConfig.id;
+  }
+
   if(typeof targetConfig.date === 'function') {
-    instance.date = targetConfig.date(c);
+    instance.date = targetConfig.date(c, r);
   } else if(targetConfig.date === undefined || targetConfig.date === 'now') {
     instance.date = now.getTime();
   } else if(targetConfig.date === 'reported') {
-    instance.date = c.reported_date;
+    instance.date = isEmittingForReport ? r.reported_date : c.contact.reported_date;
   } else {
     throw new Error('Unrecognised value for target.date: ' + targetConfig.date);
   }
-  emitTargetInstance(instance);
-}
 
-function emitReportBasedTargetFor(c, r, targetConf) {
-  var instance, pass;
-  if(targetConf.appliesIf && !targetConf.appliesIf(c, r)) return;
-
-  if(targetConf.emitCustom) {
-    targetConf.emitCustom(c, r);
+  if(targetConfig.emitCustom) {
+    targetConfig.emitCustom(instance, c, r);
     return;
   }
 
-  pass = !targetConf.passesIf || !!targetConf.passesIf(c, r);
-  instance = createTargetInstance(targetConf.id, r, pass);
-  instance._id = (targetConf.idType === 'report' ? r._id : c.contact._id) + '~' + targetConf.id;
   emitTargetInstance(instance);
-  switch(targetConf.date) {
-    case 'now': instance.date = now.getTime(); break;
-  }
 }
 
 function createTargetInstance(type, doc, pass) {

--- a/src/nools/lib.js
+++ b/src/nools/lib.js
@@ -2,9 +2,7 @@ for(idx1=0; idx1<targets.length; ++idx1) {
   target = targets[idx1];
   switch(target.appliesTo) {
     case 'contacts':
-      if(c.contact && target.appliesToType.indexOf(c.contact.type) !== -1) {
-        emitTargetFor(target, c);
-      }
+      emitTargetFor(target, c);
       break;
     case 'reports':
       for(idx2=0; idx2<c.reports.length; ++idx2) {
@@ -142,7 +140,10 @@ function emitTasksForSchedule(c, schedule, r) {
 
 function emitTargetFor(targetConfig, c, r) {
   var isEmittingForReport = !!r;
-  if(targetConfig.appliesIf && !targetConfig.appliesIf(c, r)) return;
+  if (!c.contact) return;
+  const appliesToKey = isEmittingForReport ? r.form : c.contact.type;
+  if (targetConfig.appliesToType && targetConfig.appliesToType.indexOf(appliesToKey) < 0) return;
+  if (targetConfig.appliesIf && !targetConfig.appliesIf(c, r)) return;
 
   var pass = !targetConfig.passesIf || !!targetConfig.passesIf(c, r);
   var instanceDoc = isEmittingForReport ? r : c.contact;

--- a/src/nools/lib.js
+++ b/src/nools/lib.js
@@ -148,9 +148,7 @@ function emitTargetFor(targetConfig, c, r) {
   var instanceDoc = isEmittingForReport ? r : c.contact;
   var instance = createTargetInstance(targetConfig.id, instanceDoc, pass);
 
-  if (isEmittingForReport) {
-    instance._id = (targetConfig.idType === 'report' ? r && r._id : c.contact._id) + '~' + targetConfig.id;
-  }
+  instance._id = (targetConfig.idType === 'report' ? r && r._id : c.contact._id) + '~' + targetConfig.id;
 
   if(typeof targetConfig.date === 'function') {
     instance.date = targetConfig.date(c, r);

--- a/test/nools/lib.targets.spec.js
+++ b/test/nools/lib.targets.spec.js
@@ -103,7 +103,7 @@ describe('nools lib', function() {
         // and
         const reportedDate = aRandomTimestamp();
         const contact = personWithoutReports();
-        contact.reported_date = reportedDate;
+        contact.contact.reported_date = reportedDate;
 
         // and
         const config = {
@@ -228,7 +228,7 @@ describe('nools lib', function() {
 
           // then
           assert.deepEqual(emitted, [
-            { _type:'target', _id:'c-2~rT-3' },
+            { _type:'target', _id:'c-2~rT-3', date: TEST_DATE },
             { _type:'_complete', _id:true },
           ]);
         });
@@ -245,9 +245,9 @@ describe('nools lib', function() {
 
           // then
           assert.deepEqual(emitted, [
-            { _type:'target', _id:'c-4~rT-5' },
-            { _type:'target', _id:'c-4~rT-5' },
-            { _type:'target', _id:'c-4~rT-5' },
+            { _type:'target', _id:'c-4~rT-5', date: TEST_DATE },
+            { _type:'target', _id:'c-4~rT-5', date: TEST_DATE },
+            { _type:'target', _id:'c-4~rT-5', date: TEST_DATE },
             { _type:'_complete', _id:true },
           ]);
         });
@@ -283,8 +283,8 @@ describe('nools lib', function() {
 
           // then
           assert.deepEqual(emitted, [
-            { _type:'target', _id:'c-2~rT-3' },
-            { _type:'target', _id:'c-2~rT-4' },
+            { _type:'target', _id:'c-2~rT-3', date: TEST_DATE },
+            { _type:'target', _id:'c-2~rT-4', date: TEST_DATE },
             { _type:'_complete', _id:true },
           ]);
         });
@@ -301,12 +301,12 @@ describe('nools lib', function() {
 
           // then
           assert.deepEqual(emitted, [
-            { _type:'target', _id:'c-4~rT-5' },
-            { _type:'target', _id:'c-4~rT-5' },
-            { _type:'target', _id:'c-4~rT-5' },
-            { _type:'target', _id:'c-4~rT-6' },
-            { _type:'target', _id:'c-4~rT-6' },
-            { _type:'target', _id:'c-4~rT-6' },
+            { _type:'target', _id:'c-4~rT-5', date: TEST_DATE },
+            { _type:'target', _id:'c-4~rT-5', date: TEST_DATE },
+            { _type:'target', _id:'c-4~rT-5', date: TEST_DATE },
+            { _type:'target', _id:'c-4~rT-6', date: TEST_DATE },
+            { _type:'target', _id:'c-4~rT-6', date: TEST_DATE },
+            { _type:'target', _id:'c-4~rT-6', date: TEST_DATE },
             { _type:'_complete', _id:true },
           ]);
         });

--- a/test/nools/lib.targets.spec.js
+++ b/test/nools/lib.targets.spec.js
@@ -1,5 +1,5 @@
 const chai = require('chai');
-const assert = chai.assert;
+const { expect, assert } = chai;
 chai.use(require('chai-shallow-deep-equal'));
 const {
   TEST_DATE,
@@ -141,6 +141,24 @@ describe('nools lib', function() {
           { _type:'_complete', _id:true },
         ]);
       });
+
+      it('should not emit if appliesToType doesnt match', function() {
+        // given
+        const target = aPersonBasedTarget();
+        target.appliesToType = [ 'dne' ];
+
+         const config = {
+          c: personWithReports(aReport()),
+          targets: [ target ],
+          tasks: [],
+        };
+
+         // when
+        const emitted = loadLibWith(config).emitted;
+
+         // then
+        expect(emitted).to.have.property('length', 1);
+      });
     });
 
     describe('place-based', function() {
@@ -251,6 +269,24 @@ describe('nools lib', function() {
             { _type:'_complete', _id:true },
           ]);
         });
+
+        it('should not emit if appliesToType doesnt match', function() {
+          // given
+          const target = aReportBasedTarget();
+          target.appliesToType = [ 'dne' ];
+
+           const config = {
+            c: personWithReports(aReport()),
+            targets: [ target ],
+            tasks: [],
+          };
+
+           // when
+          const emitted = loadLibWith(config).emitted;
+
+           // then
+          expect(emitted).to.have.property('length', 1);
+        });
       });
 
       describe('with multiple targets', function() {
@@ -312,6 +348,28 @@ describe('nools lib', function() {
         });
       });
     });
+
+    it('appliesToType is optional', function() {
+      // given
+      const target = aPersonBasedTarget();
+      delete target.appliesToType;
+
+       const config = {
+        c: personWithReports(aReport()),
+        targets: [ target ],
+        tasks: [],
+      };
+
+       // when
+      const emitted = loadLibWith(config).emitted;
+
+       // then
+      assert.deepEqual(emitted, [
+        { _id: 'c-3~pT-1', _type:'target', date: TEST_DATE },
+        { _type:'_complete', _id:true },
+      ]);
+    });
+
     describe('invalid target type', function() {
       it('should throw error', function() {
         // given

--- a/test/nools/lib.targets.spec.js
+++ b/test/nools/lib.targets.spec.js
@@ -104,7 +104,6 @@ describe('nools lib', function() {
         const reportedDate = aRandomTimestamp();
         const contact = personWithoutReports();
         contact.reported_date = reportedDate;
-
         // and
         const config = {
           c: contact,

--- a/test/nools/lib.targets.spec.js
+++ b/test/nools/lib.targets.spec.js
@@ -104,6 +104,7 @@ describe('nools lib', function() {
         const reportedDate = aRandomTimestamp();
         const contact = personWithoutReports();
         contact.reported_date = reportedDate;
+
         // and
         const config = {
           c: contact,


### PR DESCRIPTION
These two issues are due to inconsistencies between how targets with `appliesTo: 'reports'` and `appliesTo: 'contacts'` are processed. The code paths are very different, supporting some features for reports and some features for contacts. This converges the code paths and supports all features for both. 
#149 and #144 

While I'm in there, I'm going to get merge conflicts if I fix this one elsewhere. Changing where this `emitCustom` function is called and the data that is passed to it.
#143 

EDIT: Now also contains #158.