### PR TITLE
Fix up crashing, broken, and partially incomplete appliesToType logic

### DIFF
--- a/src/nools/lib.js
+++ b/src/nools/lib.js
@@ -2,9 +2,7 @@ for(idx1=0; idx1<targets.length; ++idx1) {
   target = targets[idx1];
   switch(target.appliesTo) {
     case 'contacts':
-      if(c.contact && target.appliesToType.indexOf(c.contact.type) !== -1) {
-        emitContactBasedTargetFor(c, target);
-      }
+      emitContactBasedTargetFor(c, target);
       break;
     case 'reports':
       for(idx2=0; idx2<c.reports.length; ++idx2) {
@@ -141,7 +139,9 @@ function emitTasksForSchedule(c, schedule, r) {
 }
 
 function emitContactBasedTargetFor(c, targetConfig) {
-  if(targetConfig.appliesIf && !targetConfig.appliesIf(c)) return;
+  if (!c.contact) return;
+  if (targetConfig.appliesToType && targetConfig.appliesToType.indexOf(c.contact.type) < 0) return;
+  if (targetConfig.appliesIf && !targetConfig.appliesIf(c)) return;
 
   var pass = !targetConfig.passesIf || !!targetConfig.passesIf(c);
 
@@ -160,7 +160,8 @@ function emitContactBasedTargetFor(c, targetConfig) {
 
 function emitReportBasedTargetFor(c, r, targetConf) {
   var instance, pass;
-  if(targetConf.appliesIf && !targetConf.appliesIf(c, r)) return;
+  if (targetConf.appliesIf && !targetConf.appliesIf(c, r)) return;
+  if (targetConf.appliesToType && targetConf.appliesToType.indexOf(r.form) < 0) return;
 
   if(targetConf.emitCustom) {
     targetConf.emitCustom(c, r);

--- a/test/nools/lib.targets.spec.js
+++ b/test/nools/lib.targets.spec.js
@@ -1,5 +1,5 @@
 const chai = require('chai');
-const assert = chai.assert;
+const { expect, assert } = chai;
 chai.use(require('chai-shallow-deep-equal'));
 const {
   TEST_DATE,
@@ -121,6 +121,7 @@ describe('nools lib', function() {
           { _type:'_complete', _id:true },
         ]);
       });
+
       it('should allow "now" as target date', function() {
         // given
         const target = aPersonBasedTarget();
@@ -140,6 +141,24 @@ describe('nools lib', function() {
           { _id: 'c-2~pT-1', _type:'target', date:TEST_DATE },
           { _type:'_complete', _id:true },
         ]);
+      });
+
+      it('should not emit if appliesToType doesnt match', function() {
+        // given
+        const target = aPersonBasedTarget();
+        target.appliesToType = [ 'dne' ];
+
+        const config = {
+          c: personWithReports(aReport()),
+          targets: [ target ],
+          tasks: [],
+        };
+
+        // when
+        const emitted = loadLibWith(config).emitted;
+
+        // then
+        expect(emitted).to.have.property('length', 1);
       });
     });
 
@@ -251,6 +270,24 @@ describe('nools lib', function() {
             { _type:'_complete', _id:true },
           ]);
         });
+
+        it('should not emit if appliesToType doesnt match', function() {
+          // given
+          const target = aReportBasedTarget();
+          target.appliesToType = [ 'dne' ];
+
+          const config = {
+            c: personWithReports(aReport()),
+            targets: [ target ],
+            tasks: [],
+          };
+
+          // when
+          const emitted = loadLibWith(config).emitted;
+
+          // then
+          expect(emitted).to.have.property('length', 1);
+        });
       });
 
       describe('with multiple targets', function() {
@@ -312,6 +349,28 @@ describe('nools lib', function() {
         });
       });
     });
+
+    it('appliesToType is optional', function() {
+      // given
+      const target = aPersonBasedTarget();
+      delete target.appliesToType;
+      
+      const config = {
+        c: personWithReports(aReport()),
+        targets: [ target ],
+        tasks: [],
+      };
+
+      // when
+      const emitted = loadLibWith(config).emitted;
+
+      // then
+      assert.deepEqual(emitted, [
+        { _id: 'c-3~pT-1', _type:'target', date: TEST_DATE },
+        { _type:'_complete', _id:true },
+      ]);
+    });
+
     describe('invalid target type', function() {
       it('should throw error', function() {
         // given


### PR DESCRIPTION
#146  tracks fixing the crash when the appliesToType is not present

When fixing this, I also discovered that the appliesToType filter isn't used at all for targets with `appliesTo: 'reports'` which I'm now also fixing here.