### PR TITLE
Ability to persist data between facts when processing nools rules

### DIFF
--- a/src/lib/compile-nools-rules.js
+++ b/src/lib/compile-nools-rules.js
@@ -10,7 +10,7 @@ const CURRENT_NOOLS_FILES = [ 'tasks.js', 'targets.js', 'nools-extras.js' ];
 
 function lint(code) {
   jshintWithReport('nools rules', code, {
-    predef: [ 'c', 'console', 'emit', 'Contact', 'Target', 'Task', 'Utils' ],
+    predef: [ 'c', 'console', 'emit', 'Contact', 'Target', 'Task', 'Utils', 'persistentState' ],
   });
 }
 
@@ -37,6 +37,8 @@ function compileWithDefaultLayout(projectDir) {
   const minifiedJs = minifyJs(jsCode);
 
   return minifyNools(`
+    global persistentState = {};
+
     define Target {
       _id: null,
       deleted: null,

--- a/src/nools/.jshintrc
+++ b/src/nools/.jshintrc
@@ -12,7 +12,8 @@
     "tasks": false,
     "Target": false,
     "Task": false,
-    "Utils": false
+    "Utils": false,
+    "persistentState": true
   },
   "undef": true,
   "unused": true


### PR DESCRIPTION
medic/medic#5493

Per our discussion yesterday, this is a quick mock up of how we could persist information within nools such that we could calculate Muso's troublesome target. @garethbowen I couldn't find details in nools' docs about "listening" for emitted instances -- but if you have details, I can try that also.  

In the meantime, I'm going to try to build a working version of the target based on this. Interested to see how it handles the corner cases we discussed like editing a family, etc.