### PR TITLE
Modify phrasing to be more accurate

### DIFF
--- a/src/bin/medic-conf.js
+++ b/src/bin/medic-conf.js
@@ -94,8 +94,8 @@ if(instanceUrl) {
   if(productionUrlMatch &&
       productionUrlMatch[1] !== projectName &&
       productionUrlMatch[1] !== 'alpha') {
-    warn(`Attempting to upload configuration for \x1b[31m${projectName}\x1b[33m`,
-        `to non-matching instance: \x1b[31m${redactBasicAuth(instanceUrl)}\x1b[33m`);
+    warn(`Attempting to use project for \x1b[31m${projectName}\x1b[33m`,
+        `against non-matching instance: \x1b[31m${redactBasicAuth(instanceUrl)}\x1b[33m`);
     if(!readline.keyInYN()) {
       error('User failed to confirm action.');
       process.exit(1);


### PR DESCRIPTION
This warn occurs regardless of whether you're uploading anything. You
could be backing up online configuration, or really interacting via
this tool in any way.