### PR TITLE
More robust argument parsing using minimist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ install:
   - "pip install --user git+https://github.com/medic/pyxform.git@medic-conf-1.17#egg=pyxform-medic"
 before_script:
   - "! grep -Fq '.only(' test/**/*.spec.js"
-  - npm install
+  - npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -6099,8 +6099,7 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -6125,7 +6124,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "googleapis": "^34.0.0",
     "jshint": "^2.9.6",
     "json2csv": "^4.3.5",
+    "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "pouchdb-adapter-http": "^7.0.0",
     "pouchdb-core": "^7.0.0",

--- a/src/bin/medic-conf.js
+++ b/src/bin/medic-conf.js
@@ -14,6 +14,12 @@ const supportedActions = require('../cli/supported-actions');
 const usage = require('../cli/usage');
 const warn = require('../lib/log').warn;
 
+// No params at all
+if(process.argv.length === 2) {
+  return checkForUpdates({ nonFatal:true })
+      .then(() => usage(0));
+}
+
 const argv = require('minimist')(process.argv.slice(2), {
   boolean: true,
   '--': true
@@ -22,11 +28,6 @@ const argv = require('minimist')(process.argv.slice(2), {
 //
 // General single use actions
 //
-if(!Object.keys(argv).length) {
-  return checkForUpdates({ nonFatal:true })
-      .then(() => usage(0));
-}
-
 if (argv.help) {
   return usage(0);
 }
@@ -46,7 +47,7 @@ if (argv.version) {
 }
 
 if (argv.changelog) {
-  console.log(fs.read(`${__dirname}/../CHANGELOG.md`));
+  console.log(fs.read(`${__dirname}/../../CHANGELOG.md`));
   return process.exit(0);
 }
 

--- a/src/bin/medic-conf.js
+++ b/src/bin/medic-conf.js
@@ -65,7 +65,7 @@ if (argv.silent) {
 //
 // Update Check?
 //
-let skipCheckForUpdates = argv.check === false;
+const skipCheckForUpdates = argv.check === false;
 
 //
 // Compile instance information
@@ -74,7 +74,7 @@ if (argv.user && !argv.instance) {
   throw new Error('The --user switch can only be used if followed by --instance');
 }
 
-let instanceUsername = argv.user || 'admin';
+const instanceUsername = argv.user || 'admin';
 let instanceUrl;
 if (argv.local) {
   if(process.env.COUCH_URL) {

--- a/src/bin/medic-conf.js
+++ b/src/bin/medic-conf.js
@@ -14,81 +14,94 @@ const supportedActions = require('../cli/supported-actions');
 const usage = require('../cli/usage');
 const warn = require('../lib/log').warn;
 
-let args = process.argv.slice(2);
-const shift = n => args = args.slice(n || 1);
+const argv = require('minimist')(process.argv.slice(2), {
+  boolean: true,
+  '--': true
+});
 
-if(!args.length) {
+//
+// General single use actions
+//
+if(!Object.keys(argv).length) {
   return checkForUpdates({ nonFatal:true })
       .then(() => usage(0));
 }
 
-let instanceUrl, skipCheckForUpdates;
-
-switch(args[0]) {
-  case '--silent':  log.level = log.LEVEL_NONE;  shift(); break;
-  case '--verbose': log.level = log.LEVEL_TRACE; shift(); break;
-  default:          log.level = log.LEVEL_INFO;
+if (argv.help) {
+  return usage(0);
 }
 
-let instanceUsername = 'admin';
-switch(args[0]) {
+if (argv['shell-completion']) {
+  return require('../cli/shell-completion-setup')(argv['shell-completion']);
+}
 
-//> instance URL handling:
-  case '--user':
-    instanceUsername = args[1];
-    shift(2);
-    if(args[0] !== '--instance') throw new Error('The --user switch can only be used if followed by --instance');
-    /* falls through */
-  case '--instance':
-    const password = readline.question(`${emoji.key}  Password: `, { hideEchoBack:true });
-    const encodedPassword = encodeURIComponent(password);
-    instanceUrl = `https://${instanceUsername}:${encodedPassword}@${args[1]}.medicmobile.org`;
-    shift(2);
-    break;
-  case '--local':
-    if(process.env.COUCH_URL) {
-      if(!process.env.COUCH_URL.match(/localhost/)) {
-        throw new Error(`You asked to configure a local instance, but the COUCH_URL env var is set to '${process.env.COUCH_URL}'.  This may be a remote server.`);
-      }
-      instanceUrl = process.env.COUCH_URL
-        .replace(/\/medic$/, '') // strip off the database
-        .replace(/:5984/, ':5988'); // use api port instead of couchdb
-      info('Using instance URL from COUCH_URL environment variable.');
-    } else {
-      instanceUrl = 'http://admin:pass@localhost:5988';
+if (argv['supported-actions']) {
+  console.log('Supported actions:\n ', supportedActions.join('\n  '));
+  return process.exit(0);
+}
+
+if (argv.version) {
+  console.log(require('../../package.json').version);
+  return process.exit(0);
+}
+
+if (argv.changelog) {
+  console.log(fs.read(`${__dirname}/../CHANGELOG.md`));
+  return process.exit(0);
+}
+
+//
+// Logging
+//
+if (argv.silent) {
+  log.level = log.LEVEL_NONE;
+} else if (argv.verbose) {
+  log.level = log.LEVEL_TRACE;
+} else {
+  log.level = log.LEVEL_INFO;
+}
+
+//
+// Update Check?
+//
+let skipCheckForUpdates = argv.check === false;
+
+//
+// Compile instance information
+//
+if (argv.user && !argv.instance) {
+  throw new Error('The --user switch can only be used if followed by --instance');
+}
+
+let instanceUsername = argv.user || 'admin';
+let instanceUrl;
+if (argv.local) {
+  if(process.env.COUCH_URL) {
+    if(!process.env.COUCH_URL.match(/localhost/)) {
+      throw new Error(`You asked to configure a local instance, but the COUCH_URL env var is set to '${process.env.COUCH_URL}'.  This may be a remote server.`);
     }
-    shift();
-    break;
-  case '--url':
-    instanceUrl = args[1];
-    shift(2);
-    break;
-
-//> general option handling:
-  case '--help': return usage(0);
-  case '--shell-completion':
-    return require('../cli/shell-completion-setup')(args[1]);
-  case '--supported-actions':
-    console.log('Supported actions:\n ', supportedActions.join('\n  '));
-    return process.exit(0);
-  case '--version':
-    console.log(require('../../package.json').version);
-    return process.exit(0);
-  case '--changelog':
-    console.log(fs.read(`${__dirname}/../CHANGELOG.md`));
-    return process.exit(0);
-}
-
-if(args[0] === '--no-check') {
-  skipCheckForUpdates = true;
-  shift();
+    instanceUrl = process.env.COUCH_URL
+      .replace(/\/medic$/, '') // strip off the database
+      .replace(/:5984/, ':5988'); // use api port instead of couchdb
+    info('Using instance URL from COUCH_URL environment variable.');
+  } else {
+    instanceUrl = 'http://admin:pass@localhost:5988';
+  }
+} else if (argv.instance) {
+  const password = readline.question(`${emoji.key}  Password: `, { hideEchoBack:true });
+  const encodedPassword = encodeURIComponent(password);
+  instanceUrl = `https://${instanceUsername}:${encodedPassword}@${argv.instance}.medicmobile.org`;
+} else if (argv.url) {
+  instanceUrl = argv.url;
 }
 
 const projectName = fs.path.basename(fs.path.resolve('.'));
 const couchUrl = instanceUrl && `${instanceUrl}/medic`;
 
 if(instanceUrl) {
-  if(instanceUrl.match('/medic$')) warn('Supplied URL ends in "/medic".  This is probably incorrect.');
+  if(instanceUrl.match('/medic$')) {
+    warn('Supplied URL ends in "/medic".  This is probably incorrect.');
+  }
 
   const productionUrlMatch = instanceUrl.match(/^https:\/\/(?:[^@]*@)?(.*)\.(app|dev)\.medicmobile\.org(?:$|\/)/);
   if(productionUrlMatch &&
@@ -103,14 +116,11 @@ if(instanceUrl) {
   }
 }
 
-let actions = args;
-let extraArgs;
-
-const argDivider = actions.indexOf('--');
-if(argDivider !== -1) {
-  extraArgs = actions.slice(argDivider + 1);
-  actions = actions.slice(0, argDivider);
-}
+//
+// Build up actions
+//
+let actions = argv._;
+let extraArgs = argv['--'];
 
 if(!actions.length) {
   actions = [
@@ -138,6 +148,9 @@ if(unsupported.length) {
   process.exit(1);
 }
 
+//
+// GO GO GO
+//
 info(`Processing config in ${projectName} for ${instanceUrl}.`);
 info('Actions:\n     -', actions.join('\n     - '));
 info('Extra args:', extraArgs);
@@ -151,7 +164,11 @@ return actions.reduce((promiseChain, action) =>
       .then(() => require(`../fn/${action}`)('.', couchUrl, extraArgs))
       .then(() => info(`${action} complete.`)),
     initialPromise)
-  .then(() => { if(actions.length > 1) info('All actions completed.'); })
+  .then(() => {
+    if (actions.length > 1) {
+      info('All actions completed.');
+    }
+  })
   .catch(e => {
     error(e);
     process.exit(1);

--- a/test/bin/medic-conf.spec.js
+++ b/test/bin/medic-conf.spec.js
@@ -4,6 +4,14 @@ const execSync = require('child_process').execSync;
 const mkdirp = require('mkdirp').sync;
 
 describe('medic-conf cli', () => {
+  describe('with no parameters', () => {
+    it('should return help', () => {
+      medicConfCli('default')
+        .then(output => {
+          assert.match(output, /medic-conf - configurerize your Medic Mobile instances/);
+        });
+    });
+  });
 
   describe('with --version flag', () => {
     it('should return a valid version number', () =>


### PR DESCRIPTION
Args can now be passed in any order, using minimist. CLI is backwards compatible with existing conventions, and also allows for using = if people prefer.

e.g.:
   --instance foo.bar
and
   --instance=foo.bar

Are equivalent.

In testing I also found the changelog command was broken so I fixed that while I was in there.