### PR TITLE
Ensure path exists before saving form attachment to disk

### DIFF
--- a/src/fn/backup-all-forms.js
+++ b/src/fn/backup-all-forms.js
@@ -25,7 +25,7 @@ module.exports = (projectDir, couchUrl) => {
         const attachmentSaves = [];
         Object.keys(form._attachments).forEach(name => {
           const att = form._attachments[name];
-          const destination = `${backupDir}/${name}`;
+          const destination = path.join(backupDir, name);
 
           if (fs.path.dirname(destination) !== backupDir) {
             fs.mkdir(fs.path.dirname(destination));

--- a/src/fn/backup-all-forms.js
+++ b/src/fn/backup-all-forms.js
@@ -25,7 +25,12 @@ module.exports = (projectDir, couchUrl) => {
         const attachmentSaves = [];
         Object.keys(form._attachments).forEach(name => {
           const att = form._attachments[name];
-          fs.writeBinary(`${backupDir}/${name}`, att.data);
+          const destination = `${backupDir}/${name}`;
+
+          if (fs.path.dirname(destination) !== backupDir) {
+            fs.mkdir(fs.path.dirname(destination));
+          }
+          fs.writeBinary(destination, att.data);
         });
         return Promise.all(attachmentSaves);
       });

--- a/src/fn/backup-all-forms.js
+++ b/src/fn/backup-all-forms.js
@@ -26,7 +26,6 @@ module.exports = (projectDir, couchUrl) => {
         Object.keys(form._attachments).forEach(name => {
           const att = form._attachments[name];
           const destination = fs.path.join(backupDir, name);
-          
 
           if (fs.path.dirname(destination) !== backupDir) {
             fs.mkdir(fs.path.dirname(destination));

--- a/src/fn/backup-all-forms.js
+++ b/src/fn/backup-all-forms.js
@@ -25,7 +25,8 @@ module.exports = (projectDir, couchUrl) => {
         const attachmentSaves = [];
         Object.keys(form._attachments).forEach(name => {
           const att = form._attachments[name];
-          const destination = path.join(backupDir, name);
+          const destination = fs.path.join(backupDir, name);
+          
 
           if (fs.path.dirname(destination) !== backupDir) {
             fs.mkdir(fs.path.dirname(destination));


### PR DESCRIPTION
Fixes #171

Image attachments are saved under an images sub-folder which wasn't
present at the time of writing to disk.