### PR TITLE
Bump uglify-js to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "medic-conf",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6124,7 +6124,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -10039,18 +10039,18 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.11.tgz",
+      "integrity": "sha512-izPJg8RsSyqxbdnqX36ExpbH3K7tDBsAU/VfNv89VkMFy3z39zFjunQGsSHOlGlyIfGLGprGeosgQno3bo2/Kg==",
       "requires": {
-        "commander": "~2.17.1",
+        "commander": "~2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
         },
         "source-map": {
           "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medic-conf",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Configure Medic Mobile deployments",
   "main": "index.js",
   "engines": {
@@ -46,7 +46,7 @@
     "request-promise-native": "^1.0.5",
     "semver": "^5.6.0",
     "svgo": "^1.1.1",
-    "uglify-js": "3.4.x",
+    "uglify-js": "^3.5.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This change effectively undoes https://github.com/medic/medic-conf/commit/9f945bc7f436abdab432cdd0de6cf4ef6c61f11b. Using uglify-js v3.4 has blocked up the upgrade of the `@medic/contact-summary-testing` package...  If I'm going to wage this war against uglify, I'm going to do it on latest.