### PR TITLE
Adding a flag to allow self signed certs when using medic-conf

### DIFF
--- a/src/bin/medic-conf.js
+++ b/src/bin/medic-conf.js
@@ -32,6 +32,10 @@ if (argv.help) {
   return usage(0);
 }
 
+if (argv['accept-self-signed-certs']) {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+}
+
 if (argv['shell-completion']) {
   return require('../cli/shell-completion-setup')(argv['shell-completion']);
 }

--- a/src/cli/usage.js
+++ b/src/cli/usage.js
@@ -50,6 +50,9 @@ ${bold('OPTIONS')}
 
 	--changelog
 		Display application changelog.
+	
+	--accept-self-signed-certs
+		Allows medic-conf to work with self signed certs by telling node to ignore the error 
 `);
 
   process.exit(exitCode);


### PR DESCRIPTION
In cases where you run docker locally or anywhere a self signed cert might be used. This flag tells node to ignore the error.