### PR TITLE
Updates `create-users` to check users-info doc count before creation

### DIFF
--- a/src/fn/create-users.js
+++ b/src/fn/create-users.js
@@ -1,52 +1,93 @@
 const fs = require('../lib/sync-fs');
-const info = require('../lib/log').info;
+const csvParse = require('csv-parse/lib/sync');
+const { info, warn, error } = require('../lib/log');
 const request = require('request-promise-native');
+const readline = require('readline-sync');
 
-module.exports = (projectDir, couchUrl) => {
-  if(!couchUrl) throw new Error('Server URL must be defined to use this function.');
-  const instanceUrl = couchUrl.replace(/\/medic$/, '');
-
-  return Promise.resolve()
-    .then(() => {
-      const csvPath = `${projectDir}/users.csv`;
-
-      if(!fs.exists(csvPath)) throw new Error(`User csv file not found at ${csvPath}`);
-
-      const { cols, rows } = fs.readCsv(csvPath);
-      const usernameIndex = cols.indexOf('username');
-      const passwordIndex = cols.indexOf('password');
-      const rolesIndex = cols.indexOf('roles');
-      const placeIdIndex = cols.indexOf('place');
-      const contactIndex = cols.indexOf('contact');
-
-      return rows.reduce((promiseChain, row) => {
-        const username = row[usernameIndex];
-        const password = row[passwordIndex];
-        const roles     = row[rolesIndex].split(':');
-        const contact = contactIndex === -1 ? prefixedProperties(cols, row, 'contact.') : row[contactIndex];
-        const place = placeIdIndex === -1 ? prefixedProperties(cols, row, 'place.') : row[placeIdIndex];
-        const requestObject = { username, password, roles, place, contact };
-
-        return promiseChain
-          .then(() => {
-            info('Creating user', username);
-            return request({
-              uri: `${instanceUrl}/api/v1/users`,
-              method: 'POST',
-              json: true,
-              body: requestObject,
-            });
-          });
-      }, Promise.resolve());
+const nestPrefixedProperties = (obj, name) => {
+  const nested = {};
+  const prefix = `${name}.`;
+  Object
+    .keys(obj)
+    .filter(key => key.startsWith(prefix))
+    .forEach(key => {
+      nested[key.substring(prefix.length)] = obj[key];
+      delete obj[key];
     });
+  return obj[name] || nested;
 };
 
-function prefixedProperties (cols, row, prefix) {
-  const indices = {};
-  cols.forEach(col => {
-    if (col.startsWith(prefix)) {
-      indices[col.substring(prefix.length)] = row[cols.indexOf(col)];
-    }
+const getUsersData = (csvData) => {
+  const users = csvParse(csvData, { columns: true });
+  users.forEach(user => {
+    user.contact = nestPrefixedProperties(user, 'contact');
+    user.place = nestPrefixedProperties(user, 'place');
+    user.roles = user.roles && user.roles.split(':');
   });
-  return indices;
-}
+  return users;
+};
+
+const getUserInfo = async (instanceUrl, user) => {
+  if (typeof user.place !== 'string') {
+    // new place - nothing to check
+    return;
+  }
+
+  const params = {
+    facility_id: user.place,
+    role: JSON.stringify(user.roles),
+  };
+  if (typeof user.contact === 'string') {
+    params.contact = user.contact;
+  }
+
+  let result;
+  try {
+    result = await request.get(`${instanceUrl}/api/v1/users-info`, { qs: params, json: true });
+  } catch (err) {
+    // we can safely ignore errors
+    // a) This endpoint was only added in 3.7, we can ignore the 404
+    // b) The endpoint throws an error if the requested roles are "online"
+    // c) The requesting authenticated user doesn't have permissions to update users, the corresponding user create request will fail
+    // d) Missing facility or role, the corresponding user create request will fail
+    if (err.statusCode !== 404 && err.statusCode !== 400) {
+      throw err;
+    }
+  }
+  return result;
+};
+
+const createUser = async (instanceUrl, user) => {
+  return request.post(`${instanceUrl}/api/v1/users`, { json: true, body: user });
+};
+
+module.exports = async (projectDir, couchUrl) => {
+  if(!couchUrl) {
+    throw new Error('Server URL must be defined to use this function.');
+  }
+
+  const instanceUrl = couchUrl.replace(/\/medic$/, '');
+  const csvPath = `${projectDir}/users.csv`;
+  if(!fs.exists(csvPath)) {
+    throw new Error(`User csv file not found at ${csvPath}`);
+  }
+
+  const users = getUsersData(fs.read(csvPath));
+  for (let user of users) {
+    info(`Requesting user-info for "${user.username}"`);
+    const userInfo = await getUserInfo(instanceUrl, user);
+    if (userInfo && userInfo.warn) {
+      warn(`The user "${user.username}" would replicate ${userInfo.total_docs}, which is above the recommended limit of ${userInfo.limit}. Are you sure you want to continue?`);
+      if(!readline.keyInYN()) {
+        error('User failed to confirm action.');
+        process.exit(1);
+        return; // stop execution in tests
+      }
+    }
+  }
+
+  for (let user of users) {
+    info(`Creating user ${user.username}`);
+    await createUser(instanceUrl, user);
+  }
+};

--- a/test/data/create-users/multiple-existing-place/users.csv
+++ b/test/data/create-users/multiple-existing-place/users.csv
@@ -1,0 +1,5 @@
+username,password,roles,contact,place
+todd,Secret_1,district-admin,contact_uuid_1,place_uuid_1
+jack,Secret_1,district-admin:supervisor,contact_uuid_2,place_uuid_2
+jill,Secret_1,role1:role2:role3,contact_uuid_3,place_uuid_3
+john,Secret_1,role2:role3,contact_uuid_4,place_uuid_4

--- a/test/fn/create-users.spec.js
+++ b/test/fn/create-users.spec.js
@@ -1,14 +1,26 @@
 const api = require('../api-stub');
 const assert = require('chai').assert;
-const createUsers = require('../../src/fn/create-users');
+const rewire = require('rewire');
+const sinon = require('sinon');
+const querystring = require('querystring');
+let createUsers;
+let readLine;
 
 describe('create-users', function() {
-  beforeEach(api.start);
-  afterEach(api.stop);
+  beforeEach(() => {
+    readLine = { keyInYN: sinon.stub() };
+    createUsers = rewire('../../src/fn/create-users');
+    createUsers.__set__('readline', readLine);
+    return api.start();
+  });
+  afterEach(() => {
+    sinon.restore();
+    return api.stop();
+  });
 
   it('should create a user with place defined as a string', function() {
     const testDir = `data/create-users/existing-place`;
-    api.giveResponses({ body: {} });
+    api.giveResponses({ body: {} }, { body: {} });
     const todd = {
       username: 'todd',
       password: 'Secret_1',
@@ -16,17 +28,242 @@ describe('create-users', function() {
       place: 'place_uuid_here',
       contact: {
         c_prop: 'c_val_a'
-      }
+      },
+      name: 'Alice Example',
+      phone: '+123456789',
+    };
+
+    const qs = {
+      facility_id: todd.place,
+      role: JSON.stringify(todd.roles),
     };
 
     return assertDbEmpty()
       .then(() => /* when */ createUsers(testDir, api.couchUrl))
-
-      .then(() =>
+      .then(() => {
         assert.deepEqual(api.requestLog(), [
-          { method: 'POST', url: '/api/v1/users', body: todd }
-        ])
-      );
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
+          { method: 'POST', url: '/api/v1/users', body: todd },
+        ]);
+      });
+  });
+
+  it('should create user with existent place and response from user-info', () => {
+    const testDir = `data/create-users/existing-place`;
+    api.giveResponses({ body: { total_docs: 1000, warn: false } }, { body: {} });
+    const todd = {
+      username: 'todd',
+      password: 'Secret_1',
+      roles: ['district-admin'],
+      place: 'place_uuid_here',
+      contact: {
+        c_prop: 'c_val_a'
+      },
+      name: 'Alice Example',
+      phone: '+123456789',
+    };
+
+    const qs = {
+      facility_id: todd.place,
+      role: JSON.stringify(todd.roles),
+    };
+
+    return assertDbEmpty()
+      .then(() => /* when */ createUsers(testDir, api.couchUrl))
+      .then(() => {
+        assert.deepEqual(api.requestLog(), [
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
+          { method: 'POST', url: '/api/v1/users', body: todd },
+        ]);
+      });
+  });
+
+  it('should create user with existent place and not implemented user-info endpoint', () => {
+    const testDir = `data/create-users/existing-place`;
+    api.giveResponses({ status: 404, body: { code: 404, error: 'not_found' } }, { body: {} });
+    const todd = {
+      username: 'todd',
+      password: 'Secret_1',
+      roles: ['district-admin'],
+      place: 'place_uuid_here',
+      contact: {
+        c_prop: 'c_val_a'
+      },
+      name: 'Alice Example',
+      phone: '+123456789',
+    };
+
+    const qs = {
+      facility_id: todd.place,
+      role: JSON.stringify(todd.roles),
+    };
+
+    return assertDbEmpty()
+      .then(() => /* when */ createUsers(testDir, api.couchUrl))
+      .then(() => {
+        assert.deepEqual(api.requestLog(), [
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
+          { method: 'POST', url: '/api/v1/users', body: todd },
+        ]);
+      });
+  });
+
+  it('should require user input before creating user with too many docs', () => {
+    const testDir = `data/create-users/existing-place`;
+    api.giveResponses({ body: { total_docs: 12000, warn: true, limit: 10000 } }, { body: {} });
+    const todd = {
+      username: 'todd',
+      password: 'Secret_1',
+      roles: ['district-admin'],
+      place: 'place_uuid_here',
+      contact: {
+        c_prop: 'c_val_a'
+      },
+      name: 'Alice Example',
+      phone: '+123456789',
+    };
+
+    readLine.keyInYN.returns(true);
+    const qs = {
+      facility_id: todd.place,
+      role: JSON.stringify(todd.roles),
+    };
+
+    return assertDbEmpty()
+      .then(() => /* when */ createUsers(testDir, api.couchUrl))
+      .then(() => {
+        assert.equal(readLine.keyInYN.callCount, 1);
+        assert.deepEqual(api.requestLog(), [
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
+          { method: 'POST', url: '/api/v1/users', body: todd },
+        ]);
+      });
+  });
+
+  it('should not create user if no input when too many docs', () => {
+    const testDir = `data/create-users/existing-place`;
+    sinon.stub(process, 'exit');
+    api.giveResponses({ body: { total_docs: 12000, warn: true, limit: 10000 } } );
+    const todd = {
+      username: 'todd',
+      password: 'Secret_1',
+      roles: ['district-admin'],
+      place: 'place_uuid_here',
+      contact: {
+        c_prop: 'c_val_a'
+      },
+      name: 'Alice Example',
+      phone: '+123456789',
+    };
+
+    readLine.keyInYN.returns(false);
+    const qs = {
+      facility_id: todd.place,
+      role: JSON.stringify(todd.roles),
+    };
+    return assertDbEmpty()
+      .then(() => /* when */ createUsers(testDir, api.couchUrl))
+      .then(() => {
+        assert.equal(readLine.keyInYN.callCount, 1);
+        assert.equal(process.exit.callCount, 1);
+        assert.deepEqual(api.requestLog(), [
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
+        ]);
+      });
+  });
+
+  it('should throw some users-info errors', () => {
+    const testDir = `data/create-users/existing-place`;
+    const todd = {
+      roles: ['district-admin'],
+      place: 'place_uuid_here',
+      contact: {
+        c_prop: 'c_val_a'
+      },
+    };
+
+    api.giveResponses({ status: 500, body: { code: 500, error: 'boom' } } );
+    const qs = {
+      facility_id: todd.place,
+      role: JSON.stringify(todd.roles),
+    };
+    return assertDbEmpty()
+      .then(() => /* when */ createUsers(testDir, api.couchUrl))
+      .then(r => assert.equal(r, 'Expected to reject'))
+      .catch(err => {
+        assert.deepEqual(err.error, { code: 500, error: 'boom' });
+        assert.equal(readLine.keyInYN.callCount, 0);
+        assert.deepEqual(api.requestLog(), [
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
+        ]);
+      });
+  });
+
+  it('should request user-info in sequence before creating users', () => {
+    const testDir = `data/create-users/multiple-existing-place`;
+    const pwd = 'Secret_1';
+    api.giveResponses(
+      { status: 400, body: { code: 400, error: 'not an offline role' } },
+      { body: { total_docs: 12000, warn: true, limit: 10000 } },
+      { body: { total_docs: 10200, warn: true, limit: 10000 } },
+      { body: { total_docs: 1000, warn: false, limit: 10000 } },
+      { body: {} },
+      { body: {} },
+      { body: {} },
+      { body: {} },
+    );
+
+    readLine.keyInYN.returns(true);
+    const todd = { username: 'todd', password: pwd, roles: ['district-admin'],  place: 'place_uuid_1', contact: 'contact_uuid_1' };
+    const jack = { username: 'jack', password: pwd, roles: ['district-admin', 'supervisor'],  place: 'place_uuid_2', contact: 'contact_uuid_2' };
+    const jill = { username: 'jill', password: pwd, roles: ['role1', 'role2', 'role3'],  place: 'place_uuid_3', contact: 'contact_uuid_3' };
+    const john = { username: 'john', password: pwd, roles: ['role2', 'role3'],  place: 'place_uuid_4', contact: 'contact_uuid_4' };
+    const qs = (user) => querystring.stringify({ facility_id: user.place, role: JSON.stringify(user.roles), contact: user.contact });
+    return assertDbEmpty()
+      .then(() => createUsers(testDir, api.couchUrl))
+      .then(() => {
+        assert.equal(readLine.keyInYN.callCount, 2);
+        assert.deepEqual(api.requestLog(), [
+          { method: 'GET', url: '/api/v1/users-info?' + qs(todd), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + qs(jack), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + qs(jill), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + qs(john), body: {} },
+          { method: 'POST', url: '/api/v1/users', body: todd },
+          { method: 'POST', url: '/api/v1/users', body: jack },
+          { method: 'POST', url: '/api/v1/users', body: jill },
+          { method: 'POST', url: '/api/v1/users', body: john },
+        ]);
+      });
+  });
+
+  it('should interrupt execution when user fails to confirm user', () => {
+    const testDir = `data/create-users/multiple-existing-place`;
+    sinon.stub(process, 'exit');
+    const pwd = 'Secret_1';
+    api.giveResponses(
+      { status: 400, body: { code: 400, error: 'not an offline role' } },
+      { body: { total_docs: 12000, warn: true, limit: 10000 } },
+      { body: { total_docs: 10200, warn: true, limit: 10000 } },
+    );
+
+    readLine.keyInYN
+      .onCall(0).returns(true)
+      .onCall(1).returns(false);
+    const todd = { username: 'todd', password: pwd, roles: ['district-admin'],  place: 'place_uuid_1', contact: 'contact_uuid_1' };
+    const jack = { username: 'jack', password: pwd, roles: ['district-admin', 'supervisor'],  place: 'place_uuid_2', contact: 'contact_uuid_2' };
+    const jill = { username: 'jill', password: pwd, roles: ['role1', 'role2', 'role3'],  place: 'place_uuid_3', contact: 'contact_uuid_3' };
+    const qs = (user) => querystring.stringify({ facility_id: user.place, role: JSON.stringify(user.roles), contact: user.contact });
+    return assertDbEmpty()
+      .then(() => createUsers(testDir, api.couchUrl))
+      .then(() => {
+        assert.equal(readLine.keyInYN.callCount, 2);
+        assert.equal(process.exit.callCount, 1);
+        assert.deepEqual(api.requestLog(), [
+          { method: 'GET', url: '/api/v1/users-info?' + qs(todd), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + qs(jack), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + qs(jill), body: {} }
+        ]);
+      });
   });
 
   it('should create one user for each row in a CSV file', function() {
@@ -47,7 +284,9 @@ describe('create-users', function() {
         name: 'alice area',
         parent: 'abc-123',
         type: 'health_center'
-      }
+      },
+      name: 'Alice Example',
+      phone: '+123456789',
     };
     const bob = {
       username: 'bob',
@@ -61,7 +300,9 @@ describe('create-users', function() {
         name: 'bob area',
         parent: 'def-456',
         type: 'health_center'
-      }
+      },
+      name: 'Bob Demo',
+      phone: '+987654321',
     };
 
     return assertDbEmpty()


### PR DESCRIPTION
Before creating users from csv, calls `api/v1/users-info` for each user and displays a warning and prompt when API warns about doc counts. 

https://github.com/medic/medic/issues/5362