### PR TITLE
Making the execute action a module so it can be used by other scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "medic-conf",
   "version": "3.0.4",
   "description": "Configure Medic Mobile deployments",
-  "main": "index.js",
+  "main": "./src/lib/execute-action.js",
   "engines": {
     "node": ">=8.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "medic-conf",
   "version": "3.0.4",
   "description": "Configure Medic Mobile deployments",
-  "main": "./src/lib/execute-action.js",
+  "main": "./src/lib/main.js",
   "engines": {
     "node": ">=8.9.0"
   },

--- a/src/bin/shell-completion.js
+++ b/src/bin/shell-completion.js
@@ -4,7 +4,8 @@
 
 const options = [
     '--instance', '--local', '--url', '--user',
-    '--help', '--shell-completion', '--supported-actions', '--version', '--accept-self-signed-certs', '--skip-dependency-check',
+    '--help', '--shell-completion', '--supported-actions',
+    '--version', '--accept-self-signed-certs', '--skip-dependency-check',
     ...require('../cli/supported-actions'),
 ];
 

--- a/src/bin/shell-completion.js
+++ b/src/bin/shell-completion.js
@@ -4,7 +4,7 @@
 
 const options = [
     '--instance', '--local', '--url', '--user',
-    '--help', '--shell-completion', '--supported-actions', '--version', '--accept-self-signed-certs',
+    '--help', '--shell-completion', '--supported-actions', '--version', '--accept-self-signed-certs', '--skip-dependency-check',
     ...require('../cli/supported-actions'),
 ];
 

--- a/src/cli/usage.js
+++ b/src/cli/usage.js
@@ -55,7 +55,7 @@ ${bold('OPTIONS')}
     Allows medic-conf to work with self signed certs by telling node to ignore the error
   
   --skip-dependency-check
-    Medic conf will not check that the version running is set to the same version in your package.json
+    Skips checking the version running is set to the same version in the package.json
 `);
 };
 

--- a/src/cli/usage.js
+++ b/src/cli/usage.js
@@ -52,7 +52,10 @@ ${bold('OPTIONS')}
     Display application changelog.
   
   --accept-self-signed-certs
-    Allows medic-conf to work with self signed certs by telling node to ignore the error 
+    Allows medic-conf to work with self signed certs by telling node to ignore the error
+  
+  --skip-dependency-check
+    Medic conf will not check that the version running is set to the same version in your package.json
 `);
 };
 

--- a/src/fn/compile-app-settings.js
+++ b/src/fn/compile-app-settings.js
@@ -12,8 +12,10 @@ const compileAppSettings = async (projectDir, couchUrl, extraArgs) => {
   const options = parseExtraArgs(extraArgs);
   projectDir = path.resolve(projectDir);
   
-  checkMedicConfDependencyVersion(projectDir);
-
+  if(options.dependencyCheck){
+    checkMedicConfDependencyVersion(projectDir);
+  }
+  
   let appSettings;
   const inheritedPath = path.join(projectDir, 'settings.inherit.json');
   if (fs.exists(inheritedPath)) {
@@ -146,6 +148,7 @@ const parseExtraArgs = (extraArgs = []) => {
     minifyScripts: !args.debug,
     haltOnWebpackWarning: !args.debug,
     haltOnLintMessage: !args.debug,
+    dependencyCheck: !args.noDependencyCheck
   };
 };
 

--- a/src/fn/compile-app-settings.js
+++ b/src/fn/compile-app-settings.js
@@ -1,7 +1,5 @@
 const minimist = require('minimist');
 const path = require('path');
-
-const checkMedicConfDependencyVersion = require('../lib/check-medic-conf-depdency-version');
 const compileContactSummary = require('../lib/compile-contact-summary');
 const compileNoolsRules = require('../lib/compile-nools-rules');
 const fs = require('../lib/sync-fs');
@@ -11,10 +9,6 @@ const { warn } = require('../lib/log');
 const compileAppSettings = async (projectDir, couchUrl, extraArgs) => {
   const options = parseExtraArgs(extraArgs);
   projectDir = path.resolve(projectDir);
-  
-  if(options.dependencyCheck){
-    checkMedicConfDependencyVersion(projectDir);
-  }
   
   let appSettings;
   const inheritedPath = path.join(projectDir, 'settings.inherit.json');

--- a/src/fn/compile-app-settings.js
+++ b/src/fn/compile-app-settings.js
@@ -142,7 +142,6 @@ const parseExtraArgs = (extraArgs = []) => {
     minifyScripts: !args.debug,
     haltOnWebpackWarning: !args.debug,
     haltOnLintMessage: !args.debug,
-    dependencyCheck: !args.noDependencyCheck
   };
 };
 

--- a/src/lib/execute-action.js
+++ b/src/lib/execute-action.js
@@ -1,2 +1,0 @@
-module.exports = (action, instanceUrl, extraArgs, projectDir) => require(`../fn/${action}`)(projectDir, instanceUrl, extraArgs);
-

--- a/src/lib/execute-action.js
+++ b/src/lib/execute-action.js
@@ -1,0 +1,2 @@
+module.exports = (action, instanceUrl, extraArgs, projectDir) => require(`../fn/${action}`)(projectDir, instanceUrl, extraArgs);
+

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -12,6 +12,7 @@ const fs = require('../lib/sync-fs');
 const supportedActions = require('../cli/supported-actions');
 const shellCompletionSetup = require('../cli/shell-completion-setup');
 const usage = require('../cli/usage');
+const executeAction = require('./execute-action');
 
 const { error, info, warn } = log;
 const defaultActions = [
@@ -172,7 +173,7 @@ module.exports = async (argv, env) => {
 
   for (let action of actions) {
     info(`Starting action: ${action}…`);
-    await executeAction(action, `${instanceUrl.href}medic`, extraArgs);
+    await executeAction(action, `${instanceUrl.href}medic`, extraArgs, '.');
     info(`${action} complete.`);
   }
 
@@ -187,6 +188,3 @@ const parseCouchUrl = COUCH_URL => {
   parsed.host = `${parsed.hostname}:5988`;
   return url.parse(url.format(parsed));
 };
-
-const executeAction = (action, instanceUrl, extraArgs) => require(`../fn/${action}`)('.', instanceUrl, extraArgs);
-

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -4,6 +4,7 @@ const opn = require('opn');
 const readline = require('readline-sync');
 const redactBasicAuth = require('redact-basic-auth');
 const url = require('url');
+const checkMedicConfDependencyVersion = require('../lib/check-medic-conf-depdency-version');
 
 const checkForUpdates = require('../lib/check-for-updates');
 const emoji = require('../lib/emoji');
@@ -12,7 +13,6 @@ const fs = require('../lib/sync-fs');
 const supportedActions = require('../cli/supported-actions');
 const shellCompletionSetup = require('../cli/shell-completion-setup');
 const usage = require('../cli/usage');
-const executeAction = require('./execute-action');
 
 const { error, info, warn } = log;
 const defaultActions = [
@@ -74,6 +74,10 @@ module.exports = async (argv, env) => {
 
   if (cmdArgs['accept-self-signed-certs']) {
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+  }
+
+  if (!cmdArgs['skip-dependency-check']) {
+    checkMedicConfDependencyVersion('.');
   }
 
   //
@@ -173,7 +177,7 @@ module.exports = async (argv, env) => {
 
   for (let action of actions) {
     info(`Starting action: ${action}…`);
-    await executeAction(action, `${instanceUrl.href}medic`, extraArgs, '.');
+    await executeAction(action, `${instanceUrl.href}medic`, extraArgs);
     info(`${action} complete.`);
   }
 
@@ -188,3 +192,6 @@ const parseCouchUrl = COUCH_URL => {
   parsed.host = `${parsed.hostname}:5988`;
   return url.parse(url.format(parsed));
 };
+
+const executeAction = (action, instanceUrl, extraArgs) => require(`../fn/${action}`)('.', instanceUrl, extraArgs);
+

--- a/test/bin/shell-completion.spec.js
+++ b/test/bin/shell-completion.spec.js
@@ -17,6 +17,7 @@ describe('shell-completion', () => {
         '--supported-actions',
         '--version',
         '--accept-self-signed-certs',
+        '--skip-dependency-check',
 
         'backup-all-forms',
         'backup-app-settings',

--- a/test/lib/main.spec.js
+++ b/test/lib/main.spec.js
@@ -72,7 +72,7 @@ describe('main', () => {
     await main([...normalArgv, '--local'], {});
     
     expect(mocks.executeAction.callCount).to.deep.eq(defaultActions.length);
-    expect(mocks.executeAction.args[0]).to.deep.eq(['compile-app-settings', 'http://admin:pass@localhost:5988/medic', undefined]);
+    expect(mocks.executeAction.args[0]).to.deep.eq(['compile-app-settings', 'http://admin:pass@localhost:5988/medic', undefined, '.']);
   });
 
   it('--local with COUCH_URL to localhost', async () => {
@@ -80,7 +80,7 @@ describe('main', () => {
     await main([...normalArgv, '--local'], { COUCH_URL });
     
     expect(mocks.executeAction.callCount).to.deep.eq(defaultActions.length);
-    expect(mocks.executeAction.args[0]).to.deep.eq(['compile-app-settings', 'http://user:pwd@localhost:5988/medic', undefined]);
+    expect(mocks.executeAction.args[0]).to.deep.eq(['compile-app-settings', 'http://user:pwd@localhost:5988/medic', undefined, '.']);
   });
 
   it('--local with COUCH_URL to non-localhost yields error', async () => {
@@ -101,7 +101,7 @@ describe('main', () => {
   it('--instance + 2 ordered actions', async () => {
     await main([...normalArgv, '--instance=test.app', 'convert-app-forms', 'compile-app-settings'], {});
     expect(mocks.executeAction.callCount).to.deep.eq(2);
-    expect(mocks.executeAction.args[0]).to.deep.eq(['convert-app-forms', 'https://admin:pwd@test.app.medicmobile.org/medic', undefined]);
+    expect(mocks.executeAction.args[0]).to.deep.eq(['convert-app-forms', 'https://admin:pwd@test.app.medicmobile.org/medic', undefined, '.']);
     expect(mocks.executeAction.args[1][0]).to.eq('compile-app-settings');
   });
 
@@ -109,7 +109,7 @@ describe('main', () => {
     const formName = 'form-name';
     await main([...normalArgv, '--local', 'convert-app-forms', '--', formName], {});
     expect(mocks.executeAction.callCount).to.deep.eq(1);
-    expect(mocks.executeAction.args[0]).to.deep.eq(['convert-app-forms', 'http://admin:pass@localhost:5988/medic', [formName]]);
+    expect(mocks.executeAction.args[0]).to.deep.eq(['convert-app-forms', 'http://admin:pass@localhost:5988/medic', [formName], '.']);
   });
 
   it('unsupported action', async () => {

--- a/test/lib/main.spec.js
+++ b/test/lib/main.spec.js
@@ -15,6 +15,7 @@ describe('main', () => {
       shellCompletionSetup: sinon.stub(),
       error: sinon.stub(),
       info: sinon.stub(),
+      checkMedicConfDependencyVersion: sinon.stub(),
       warn: sinon.stub(),
       executeAction: sinon.stub(),
       readline: {
@@ -62,6 +63,16 @@ describe('main', () => {
     expect(mocks.info.args[0]).to.match(/[0-9]+\.[0-9]+\.[0-9]/);
   });
 
+  it('--skip-dependency-check', async () => {
+    await main([...normalArgv, '--skip-dependency-check'], {});
+    expect(mocks.checkMedicConfDependencyVersion.callCount).to.eq(0);
+  });
+
+  it('medic conf dependency checked', async () => {
+    await main([...normalArgv, '--local'], {});
+    expect(mocks.checkMedicConfDependencyVersion.calledOnce).to.be.true;
+  });
+
   it('--local --accept-self-signed-certs', async () => {
     await main([...normalArgv, '--local', '--accept-self-signed-certs'], {});
     expect(mocks.executeAction.callCount).to.deep.eq(defaultActions.length);
@@ -72,7 +83,7 @@ describe('main', () => {
     await main([...normalArgv, '--local'], {});
     
     expect(mocks.executeAction.callCount).to.deep.eq(defaultActions.length);
-    expect(mocks.executeAction.args[0]).to.deep.eq(['compile-app-settings', 'http://admin:pass@localhost:5988/medic', undefined, '.']);
+    expect(mocks.executeAction.args[0]).to.deep.eq(['compile-app-settings', 'http://admin:pass@localhost:5988/medic', undefined]);
   });
 
   it('--local with COUCH_URL to localhost', async () => {
@@ -80,7 +91,7 @@ describe('main', () => {
     await main([...normalArgv, '--local'], { COUCH_URL });
     
     expect(mocks.executeAction.callCount).to.deep.eq(defaultActions.length);
-    expect(mocks.executeAction.args[0]).to.deep.eq(['compile-app-settings', 'http://user:pwd@localhost:5988/medic', undefined, '.']);
+    expect(mocks.executeAction.args[0]).to.deep.eq(['compile-app-settings', 'http://user:pwd@localhost:5988/medic', undefined]);
   });
 
   it('--local with COUCH_URL to non-localhost yields error', async () => {
@@ -101,7 +112,7 @@ describe('main', () => {
   it('--instance + 2 ordered actions', async () => {
     await main([...normalArgv, '--instance=test.app', 'convert-app-forms', 'compile-app-settings'], {});
     expect(mocks.executeAction.callCount).to.deep.eq(2);
-    expect(mocks.executeAction.args[0]).to.deep.eq(['convert-app-forms', 'https://admin:pwd@test.app.medicmobile.org/medic', undefined, '.']);
+    expect(mocks.executeAction.args[0]).to.deep.eq(['convert-app-forms', 'https://admin:pwd@test.app.medicmobile.org/medic', undefined]);
     expect(mocks.executeAction.args[1][0]).to.eq('compile-app-settings');
   });
 
@@ -109,7 +120,7 @@ describe('main', () => {
     const formName = 'form-name';
     await main([...normalArgv, '--local', 'convert-app-forms', '--', formName], {});
     expect(mocks.executeAction.callCount).to.deep.eq(1);
-    expect(mocks.executeAction.args[0]).to.deep.eq(['convert-app-forms', 'http://admin:pass@localhost:5988/medic', [formName], '.']);
+    expect(mocks.executeAction.args[0]).to.deep.eq(['convert-app-forms', 'http://admin:pass@localhost:5988/medic', [formName]]);
   });
 
   it('unsupported action', async () => {


### PR DESCRIPTION
Moved the executeAction code into a module and now medic-conf can be required after npm install. Now we can use the medic-conf code to apply configs from code.