### PR TITLE
Issue with auto generation of UUIDs and missing reported date on docs

### DIFF
--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -121,6 +121,7 @@ module.exports = (projectDir)=> {
 
   function processCsv(docType, cols, row, baseDoc) {
     const doc = baseDoc || {};
+    const _idIndex = cols.indexOf('_id');
     doc.type = docType;
 
     for(let i=0; i<cols.length; ++i) {
@@ -138,7 +139,7 @@ module.exports = (projectDir)=> {
       });
     }
 
-    return withId(doc);
+    return _idIndex === -1 ? withId(doc) : doc;
   }
 
   function withId(json) {

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -138,6 +138,9 @@ module.exports = (projectDir)=> {
         propertyName: col,
       });
     }
+    if(docType !== 'users'){
+      doc.reported_date = Date.now();
+    }
 
     return _idIndex === -1 ? withId(doc) : doc;
   }


### PR DESCRIPTION
# Description
Recently I have been using `medic-conf v3.0.4` to create and upload both contacts and users for RHITESE MoH-HFQAP in Uganda. I have come to realize that:
- During csv-to-docs conversion the docs never receive a `reported_date` field which is required when uploading contacts. It throws this error `forbidden: reported_date property must be set` in the upload-docs log file unless you manually generate reported_date and include it in the CSV file as a field.
- Creating users for existing contacts requires that you have UUIDs for the contacts to attach to users. Current version automatically generates UUIDs during contact creation making it hard to obtain these contact UUIDs especially when this is done in bulk.
## Type of changes
- I have added automatic generation of `reported_date` field.
- I have made automatic contact UUIDs optional. If UUIDs are provided in the CSV file `medic-conf` uses those otherwise automatically generated UUIDs are provided.
## Tests
Tested on RHITES and LG-UG Instances.