### PR TITLE
Added auto generation of reported_date and option to use custom UUIDs

### DIFF
--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -121,6 +121,7 @@ module.exports = (projectDir)=> {
 
   function processCsv(docType, cols, row, baseDoc) {
     const doc = baseDoc || {};
+    const _idIndex = cols.indexOf('_id');
     doc.type = docType;
 
     for(let i=0; i<cols.length; ++i) {
@@ -137,8 +138,11 @@ module.exports = (projectDir)=> {
         propertyName: col,
       });
     }
+    if(docType !== 'users'){
+      doc.reported_date = Date.now();
+    }
 
-    return withId(doc);
+    return _idIndex === -1 ? withId(doc) : doc;
   }
 
   function withId(json) {

--- a/test/data/csv-to-docs/bool/json_docs/09efb53f-9cd8-524c-9dfd-f62c242f1817.doc.json
+++ b/test/data/csv-to-docs/bool/json_docs/09efb53f-9cd8-524c-9dfd-f62c242f1817.doc.json
@@ -1,0 +1,7 @@
+{
+  "form": "simple_booleans",
+  "type": "data_record",
+  "row_count": "one",
+  "bool_1": false,
+  "_id": "09efb53f-9cd8-524c-9dfd-f62c242f1817"
+}

--- a/test/data/csv-to-docs/bool/json_docs/0ebca32d-c1b7-5522-94a3-97dd8b3df146.doc.json
+++ b/test/data/csv-to-docs/bool/json_docs/0ebca32d-c1b7-5522-94a3-97dd8b3df146.doc.json
@@ -1,0 +1,7 @@
+{
+  "form": "simple_booleans",
+  "type": "data_record",
+  "row_count": "eight",
+  "bool_1": true,
+  "_id": "0ebca32d-c1b7-5522-94a3-97dd8b3df146"
+}

--- a/test/data/csv-to-docs/bool/json_docs/288e0f1b-8c38-5385-8b9e-e162f0a46bf4.doc.json
+++ b/test/data/csv-to-docs/bool/json_docs/288e0f1b-8c38-5385-8b9e-e162f0a46bf4.doc.json
@@ -1,0 +1,7 @@
+{
+  "form": "simple_booleans",
+  "type": "data_record",
+  "row_count": "three",
+  "bool_1": false,
+  "_id": "288e0f1b-8c38-5385-8b9e-e162f0a46bf4"
+}

--- a/test/data/csv-to-docs/bool/json_docs/755c8950-01ff-5c7f-b769-23a582b275b0.doc.json
+++ b/test/data/csv-to-docs/bool/json_docs/755c8950-01ff-5c7f-b769-23a582b275b0.doc.json
@@ -1,0 +1,7 @@
+{
+  "form": "simple_booleans",
+  "type": "data_record",
+  "row_count": "four",
+  "bool_1": false,
+  "_id": "755c8950-01ff-5c7f-b769-23a582b275b0"
+}

--- a/test/data/csv-to-docs/bool/json_docs/7ac33d1f-10d8-5198-b39d-9d61595292f6.doc.json
+++ b/test/data/csv-to-docs/bool/json_docs/7ac33d1f-10d8-5198-b39d-9d61595292f6.doc.json
@@ -1,0 +1,7 @@
+{
+  "form": "simple_booleans",
+  "type": "data_record",
+  "row_count": "six",
+  "bool_1": true,
+  "_id": "7ac33d1f-10d8-5198-b39d-9d61595292f6"
+}

--- a/test/data/csv-to-docs/bool/json_docs/953c7459-3ead-5073-a7f7-18b8a4ba04d0.doc.json
+++ b/test/data/csv-to-docs/bool/json_docs/953c7459-3ead-5073-a7f7-18b8a4ba04d0.doc.json
@@ -1,0 +1,7 @@
+{
+  "form": "simple_booleans",
+  "type": "data_record",
+  "row_count": "five",
+  "bool_1": true,
+  "_id": "953c7459-3ead-5073-a7f7-18b8a4ba04d0"
+}

--- a/test/data/csv-to-docs/bool/json_docs/b492ed31-cf17-55e8-a5fb-2e08a6505097.doc.json
+++ b/test/data/csv-to-docs/bool/json_docs/b492ed31-cf17-55e8-a5fb-2e08a6505097.doc.json
@@ -1,0 +1,7 @@
+{
+  "form": "simple_booleans",
+  "type": "data_record",
+  "row_count": "seven",
+  "bool_1": true,
+  "_id": "b492ed31-cf17-55e8-a5fb-2e08a6505097"
+}

--- a/test/data/csv-to-docs/bool/json_docs/cd3e3de9-77be-548c-8a20-8fef01fa603b.doc.json
+++ b/test/data/csv-to-docs/bool/json_docs/cd3e3de9-77be-548c-8a20-8fef01fa603b.doc.json
@@ -1,0 +1,7 @@
+{
+  "form": "simple_booleans",
+  "type": "data_record",
+  "row_count": "two",
+  "bool_1": false,
+  "_id": "cd3e3de9-77be-548c-8a20-8fef01fa603b"
+}


### PR DESCRIPTION
# Description
Recently I have been using `medic-conf v3.0.4` to create and upload both contacts and users for RHITESE MoH-HFQAP in Uganda. I have come to realize that:
- During csv-to-docs conversion the docs never receive a `reported_date` field which is required when uploading contacts. It throws this error `forbidden: reported_date property must be set` in the upload-docs log file unless you manually generate reported_date and include it in the CSV file as a field.
- Creating users for existing contacts requires that you have UUIDs for the contacts to attach to users. Current version automatically generates UUIDs during contact creation making it hard to obtain these contact UUIDs especially when this is done in bulk.
## Type of changes
- I have added automatic generation of `reported_date` field.
- I have made automatic contact UUIDs optional. If UUIDs are provided in the CSV file `medic-conf` uses those otherwise automatically generated UUIDs are provided.
## Tests
Tested on RHITES and LG-UG Instances.