### PR TITLE
Added auto generated reported_date and user defined UUIDs capabilities for contacts

### DIFF
--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -122,7 +122,6 @@ module.exports = (projectDir)=> {
   function processCsv(docType, cols, row, baseDoc) {
     const doc = baseDoc || {};
     doc.type = docType;
-    doc.reported = Date.now();
 
     for(let i=0; i<cols.length; ++i) {
       const { col, val, reference, excluded } = parseColumn(cols[i], row[i]);
@@ -137,6 +136,10 @@ module.exports = (projectDir)=> {
         doc: doc,
         propertyName: col,
       });
+    }
+
+    if(cols.indexOf('reported_date') === -1){
+      doc.reported_date = Date.now();
     }
     
     if(cols.indexOf('_id') !== -1){

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -122,7 +122,7 @@ module.exports = (projectDir)=> {
   function processCsv(docType, cols, row, baseDoc) {
     const doc = baseDoc || {};
     doc.type = docType;
-    doc.reported_date = Date.now();
+    doc.reported = Date.now();
 
     for(let i=0; i<cols.length; ++i) {
       const { col, val, reference, excluded } = parseColumn(cols[i], row[i]);

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -138,10 +138,6 @@ module.exports = (projectDir)=> {
       });
     }
 
-    if(cols.indexOf('reported_date') === -1){
-      doc.reported_date = Date.now();
-    }
-    
     if(cols.indexOf('_id') !== -1){
       return doc;
     }

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -137,6 +137,9 @@ module.exports = (projectDir)=> {
         propertyName: col,
       });
     }
+    if(cols.indexOf('_id') !== -1){
+      return doc;
+    }
 
     return withId(doc);
   }

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -121,7 +121,6 @@ module.exports = (projectDir)=> {
 
   function processCsv(docType, cols, row, baseDoc) {
     const doc = baseDoc || {};
-    const _idIndex = cols.indexOf('_id');
     doc.type = docType;
 
     for(let i=0; i<cols.length; ++i) {

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -138,7 +138,7 @@ module.exports = (projectDir)=> {
       });
     }
     if(docType !== 'user'){
-      doc.reported_date = Date.now();
+      doc.reported_date = stringify(Date.now());
     }
 
     if(cols.indexOf('_id') !== -1){

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -138,7 +138,6 @@ module.exports = (projectDir)=> {
       });
     }
 
-    doc.reported_date = Date.now();
     if(cols.indexOf('_id') !== -1){
       return doc;
     }

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -122,6 +122,7 @@ module.exports = (projectDir)=> {
   function processCsv(docType, cols, row, baseDoc) {
     const doc = baseDoc || {};
     doc.type = docType;
+    doc.reported_date = Date.now();
 
     for(let i=0; i<cols.length; ++i) {
       const { col, val, reference, excluded } = parseColumn(cols[i], row[i]);
@@ -137,15 +138,17 @@ module.exports = (projectDir)=> {
         propertyName: col,
       });
     }
+    
+    if(cols.indexOf('_id') !== -1){
+      return doc;
+    }
 
     return withId(doc);
   }
 
   function withId(json) {
     const id = uuid5(stringify(json), couchUrlUuid);
-    const reported = Date.now();
     json._id = id;
-    json.reported_date = reported;
     return json;
   }
 };

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -137,10 +137,8 @@ module.exports = (projectDir)=> {
         propertyName: col,
       });
     }
-    if(docType !== 'user'){
-      doc.reported_date = stringify(Date.now());
-    }
 
+    doc.reported_date = 'hello';
     if(cols.indexOf('_id') !== -1){
       return doc;
     }

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -138,18 +138,14 @@ module.exports = (projectDir)=> {
       });
     }
 
-    const wordd = 'date';
-    doc.reported_date = wordd;
-    if(cols.indexOf('_id') !== -1){
-      return doc;
-    }
-
     return withId(doc);
   }
 
   function withId(json) {
     const id = uuid5(stringify(json), couchUrlUuid);
+    const reported = Date.now();
     json._id = id;
+    json.reported_date = reported;
     return json;
   }
 };

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -139,7 +139,7 @@ module.exports = (projectDir)=> {
     }
 
     const wordd = 'date';
-    doc.reported_date = word;
+    doc.reported_date = wordd;
     if(cols.indexOf('_id') !== -1){
       return doc;
     }

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -121,6 +121,7 @@ module.exports = (projectDir)=> {
 
   function processCsv(docType, cols, row, baseDoc) {
     const doc = baseDoc || {};
+    const reported_date = Date.now();
     doc.type = docType;
 
     for(let i=0; i<cols.length; ++i) {
@@ -146,8 +147,8 @@ module.exports = (projectDir)=> {
   }
 
   function withId(json) {
-    const id = uuid5(stringify(json), couchUrlUuid);
-    json._id = id;
+    //const id = uuid5(stringify(json), couchUrlUuid);
+    json._id = Date.now();
     return json;
   }
 };

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -137,6 +137,8 @@ module.exports = (projectDir)=> {
         propertyName: col,
       });
     }
+
+    doc.reported_date = Date.now();
     if(cols.indexOf('_id') !== -1){
       return doc;
     }

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -137,6 +137,9 @@ module.exports = (projectDir)=> {
         propertyName: col,
       });
     }
+    if(docType !== 'user'){
+      doc.reported_date = Date.now();
+    }
 
     if(cols.indexOf('_id') !== -1){
       return doc;

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -138,7 +138,8 @@ module.exports = (projectDir)=> {
       });
     }
 
-    doc.reported_date = 'hello';
+    const wordd = 'date';
+    doc.reported_date = word;
     if(cols.indexOf('_id') !== -1){
       return doc;
     }

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -121,6 +121,7 @@ module.exports = (projectDir)=> {
 
   function processCsv(docType, cols, row, baseDoc) {
     const doc = baseDoc || {};
+    const _idIndex = cols.indexOf('_id');
     doc.type = docType;
 
     for(let i=0; i<cols.length; ++i) {

--- a/test/data/compile-app-settings/eslint-error/project/targets.js
+++ b/test/data/compile-app-settings/eslint-error/project/targets.js
@@ -1,4 +1,4 @@
-var id = 'active-pregnancies'
+var id = 'active-pregnancies';
 
 module.exports = [
   {

--- a/test/data/compile-app-settings/eslint-error/project/targets.js
+++ b/test/data/compile-app-settings/eslint-error/project/targets.js
@@ -1,4 +1,4 @@
-var id = 'active-pregnancies';
+var id = 'active-pregnancies'
 
 module.exports = [
   {


### PR DESCRIPTION
# Description
Recently I have been using `medic-conf v3.0.4` to create and upload both contacts and users for RHITESE MoH-HFQAP in Uganda. I have come to realize that:
- During csv-to-docs conversion the docs never receive a `reported_date` field which is required when uploading contacts. It throws this error `forbidden: reported_date property must be set` in the upload-docs log file unless you manually generate reported_date and include it in the CSV file as a field.
- Creating users for existing contacts requires that you have UUIDs for the contacts to attach to users. Current version automatically generates UUIDs during contact creation making it hard to obtain these contact UUIDs especially when this is done in bulk.
## Type of changes
- I have added automatic generation of `reported_date` field.
- I have made automatic contact UUIDs optional. If UUIDs are provided in the CSV file `medic-conf` uses those otherwise automatically generated UUIDs are provided.
## Tests
Tested on RHITES and LG-UG Instances.