### PR TITLE
Remove record uploading from default actions

### DIFF
--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -29,8 +29,6 @@ const defaultActions = [
   'upload-contact-forms',
   'upload-resources',
   'upload-custom-translations',
-  'csv-to-docs',
-  'upload-docs',
 ];
 
 module.exports = async (argv, env) => {


### PR DESCRIPTION
The csv-to-docs and upload-docs actions are used to upload test data,
and as such don't really make sense as part of the default upload.