### PR TITLE
Ability to have user defined UUIDs

### DIFF
--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -138,6 +138,10 @@ module.exports = (projectDir)=> {
       });
     }
 
+    if(cols.indexOf('_id') !== -1){
+      return doc;
+    }
+
     return withId(doc);
   }
 


### PR DESCRIPTION
# Description
Recently I have been using `medic-conf v3.0.4` to create and upload both contacts and users for RHITESE MoH-HFQAP Uganda. I have come to realize that:
- Creating users for contacts is hard especially when its done in bulk. First i'd create contacts and they receive UUIDs automatically. Now attaching users to these contacts becomes hard since you have to look for all UUIDs of created contacts. Solution was to generate list of UUIDs i can use for contact creation and reference this list during users creation. 
## Type of changes
- I have made automatic contact UUIDs optional. If UUIDs are provided in the CSV file `medic-conf` uses those otherwise automatically generated UUIDs are provided.