### PR TITLE
Adds two new types to produce relative timestamps and relative dates

### DIFF
--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -247,7 +247,9 @@ function parseColumn(rawCol, rawVal) {
     const type = parts[1];
     switch(type) {
       case 'date': val = new Date(rawVal); break;
+      case 'rel-date': val = new Date(new Date().getTime() + (parseInt(rawVal) * 24 * 60 * 60 * 1000)); break;
       case 'timestamp': val = parseTimestamp(rawVal); break;
+      case 'rel-timestamp': val = new Date().getTime() + (parseInt(rawVal) * 24 * 60 * 60 * 1000); break;
       case 'int': val = int(rawVal); break;
       case 'bool': val = parseBool(rawVal); break;
       case 'string': val = rawVal; break;

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -210,8 +210,12 @@ function parseBool(b) {
   else return b.toLowerCase() === 'true';
 }
 
-function calcRelTimestamp(b) {
+function calcRelTimestampInDays(b) {
   return new Date().getTime() + (parseInt(b) * 24 * 60 * 60 * 1000);
+}
+
+function calcRelTimestampInMilliseconds(b) {
+  return new Date().getTime() + parseInt(b);
 }
 
 function isIntegerString(s) {
@@ -251,9 +255,9 @@ function parseColumn(rawCol, rawVal) {
     const type = parts[1];
     switch(type) {
       case 'date': val = new Date(rawVal); break;
-      case 'rel-date': val = new Date(calcRelTimestamp(rawVal)); break;
+      case 'rel-date': val = (new Date(calcRelTimestampInDays(rawVal))).toISOString().substring(0, 10); break;
       case 'timestamp': val = parseTimestamp(rawVal); break;
-      case 'rel-timestamp': val = calcRelTimestamp(rawVal); break;
+      case 'rel-timestamp': val = calcRelTimestampInMilliseconds(rawVal); break;
       case 'int': val = int(rawVal); break;
       case 'bool': val = parseBool(rawVal); break;
       case 'string': val = rawVal; break;

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -11,6 +11,7 @@ const pretty = o => JSON.stringify(o, null, 2);
 const RESERVED_COL_NAMES = [ 'type', 'form' ];
 const REF_MATCHER = /^(?:GET )?((\w+) OF )?(\w+) WHERE (.*)$/i;
 const PLACE_TYPES = [ 'clinic', 'district_hospital', 'health_center' ];
+const NOW = new Date().getTime();
 
 require('../lib/polyfill');
 
@@ -211,11 +212,11 @@ function parseBool(b) {
 }
 
 function calcRelTimestampInDays(b) {
-  return new Date().getTime() + (parseInt(b) * 24 * 60 * 60 * 1000);
+  return NOW + (parseInt(b) * 24 * 60 * 60 * 1000);
 }
 
 function calcRelTimestampInMilliseconds(b) {
-  return new Date().getTime() + parseInt(b);
+  return NOW + parseInt(b);
 }
 
 function isIntegerString(s) {

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -210,6 +210,10 @@ function parseBool(b) {
   else return b.toLowerCase() === 'true';
 }
 
+function calcRelTimestamp(b) {
+  return new Date().getTime() + (parseInt(b) * 24 * 60 * 60 * 1000);
+}
+
 function isIntegerString(s) {
   return int(s).toString() === s;
 }
@@ -247,9 +251,9 @@ function parseColumn(rawCol, rawVal) {
     const type = parts[1];
     switch(type) {
       case 'date': val = new Date(rawVal); break;
-      case 'rel-date': val = new Date(new Date().getTime() + (parseInt(rawVal) * 24 * 60 * 60 * 1000)); break;
+      case 'rel-date': val = new Date(calcRelTimestamp(rawVal)); break;
       case 'timestamp': val = parseTimestamp(rawVal); break;
-      case 'rel-timestamp': val = new Date().getTime() + (parseInt(rawVal) * 24 * 60 * 60 * 1000); break;
+      case 'rel-timestamp': val = calcRelTimestamp(rawVal); break;
       case 'int': val = int(rawVal); break;
       case 'bool': val = parseBool(rawVal); break;
       case 'string': val = rawVal; break;

--- a/src/fn/csv-to-docs.js
+++ b/src/fn/csv-to-docs.js
@@ -11,7 +11,8 @@ const pretty = o => JSON.stringify(o, null, 2);
 const RESERVED_COL_NAMES = [ 'type', 'form' ];
 const REF_MATCHER = /^(?:GET )?((\w+) OF )?(\w+) WHERE (.*)$/i;
 const PLACE_TYPES = [ 'clinic', 'district_hospital', 'health_center' ];
-const NOW = new Date().getTime();
+
+let NOW = new Date().getTime();
 
 require('../lib/polyfill');
 
@@ -279,7 +280,12 @@ function parseColumn(rawCol, rawVal) {
   return { col:col, val:val, reference:reference, excluded:excluded };
 }
 
+function setNOW(t) {
+  NOW = t;
+}
+
 module.exports = {
   requiresInstance: false,
-  execute
+  execute,
+  setNOW
 };

--- a/test/data/csv-to-docs/rel-dates/csv/report.relative_dates.csv
+++ b/test/data/csv-to-docs/rel-dates/csv/report.relative_dates.csv
@@ -1,0 +1,2 @@
+date_1:rel-date
+10

--- a/test/data/csv-to-docs/rel-dates/expected-json_docs/a73f33a9-b3ff-51b6-85d6-c18a65d85bb6.doc.json
+++ b/test/data/csv-to-docs/rel-dates/expected-json_docs/a73f33a9-b3ff-51b6-85d6-c18a65d85bb6.doc.json
@@ -1,0 +1,6 @@
+{
+  "form": "relative_dates",
+  "type": "data_record",
+  "date_1": "1970-01-11",
+  "_id": "a73f33a9-b3ff-51b6-85d6-c18a65d85bb6"
+}

--- a/test/data/csv-to-docs/rel-dates/expected-json_docs/f4ed6b3d-a89c-5d2a-9da4-e6c88d6f2e48.doc.json
+++ b/test/data/csv-to-docs/rel-dates/expected-json_docs/f4ed6b3d-a89c-5d2a-9da4-e6c88d6f2e48.doc.json
@@ -1,0 +1,6 @@
+{
+  "form": "relative_dates",
+  "type": "data_record",
+  "date_1": "1970-01-11T00:00:00.000Z",
+  "_id": "f4ed6b3d-a89c-5d2a-9da4-e6c88d6f2e48"
+}

--- a/test/data/csv-to-docs/rel-dates/expected-json_docs/f4ed6b3d-a89c-5d2a-9da4-e6c88d6f2e48.doc.json
+++ b/test/data/csv-to-docs/rel-dates/expected-json_docs/f4ed6b3d-a89c-5d2a-9da4-e6c88d6f2e48.doc.json
@@ -1,6 +1,0 @@
-{
-  "form": "relative_dates",
-  "type": "data_record",
-  "date_1": "1970-01-11T00:00:00.000Z",
-  "_id": "f4ed6b3d-a89c-5d2a-9da4-e6c88d6f2e48"
-}

--- a/test/data/csv-to-docs/rel-timestamps/csv/report.relative_timestamps.csv
+++ b/test/data/csv-to-docs/rel-timestamps/csv/report.relative_timestamps.csv
@@ -1,0 +1,4 @@
+timestamp_1:rel-timestamp
+-10
+0
+10

--- a/test/data/csv-to-docs/rel-timestamps/csv/report.relative_timestamps.csv
+++ b/test/data/csv-to-docs/rel-timestamps/csv/report.relative_timestamps.csv
@@ -1,4 +1,4 @@
 timestamp_1:rel-timestamp
--10
+-864000000
 0
-10
+864000000

--- a/test/data/csv-to-docs/rel-timestamps/expected-json_docs/0ca88f29-6ab4-596b-a04b-9dc40536cbdc.doc.json
+++ b/test/data/csv-to-docs/rel-timestamps/expected-json_docs/0ca88f29-6ab4-596b-a04b-9dc40536cbdc.doc.json
@@ -1,0 +1,6 @@
+{
+  "form": "relative_timestamps",
+  "type": "data_record",
+  "timestamp_1": 0,
+  "_id": "0ca88f29-6ab4-596b-a04b-9dc40536cbdc"
+}

--- a/test/data/csv-to-docs/rel-timestamps/expected-json_docs/4c9f8dfa-9463-5c05-afea-e19f087168ee.doc.json
+++ b/test/data/csv-to-docs/rel-timestamps/expected-json_docs/4c9f8dfa-9463-5c05-afea-e19f087168ee.doc.json
@@ -1,0 +1,6 @@
+{
+  "form": "relative_timestamps",
+  "type": "data_record",
+  "timestamp_1": -864000000,
+  "_id": "4c9f8dfa-9463-5c05-afea-e19f087168ee"
+}

--- a/test/data/csv-to-docs/rel-timestamps/expected-json_docs/def312ea-2bdd-59af-afc1-6800e87e526f.doc.json
+++ b/test/data/csv-to-docs/rel-timestamps/expected-json_docs/def312ea-2bdd-59af-afc1-6800e87e526f.doc.json
@@ -1,0 +1,6 @@
+{
+  "form": "relative_timestamps",
+  "type": "data_record",
+  "timestamp_1": 864000000,
+  "_id": "def312ea-2bdd-59af-afc1-6800e87e526f"
+}

--- a/test/fn/csv-to-docs.spec.js
+++ b/test/fn/csv-to-docs.spec.js
@@ -5,10 +5,18 @@ const csvToDocs = require('../../src/fn/csv-to-docs');
 const environment = require('../../src/lib/environment');
 const fs = require('../../src/lib/sync-fs');
 
+let clock;
+
 describe('csv-to-docs', function() {
   this.timeout(30000); // allow time for slow things
+  
+  beforeEach(function () {
+    clock = sinon.useFakeTimers();
+  });
 
-  sinon.useFakeTimers(0);
+  afterEach(function () {
+    clock.restore();
+  });
 
   const testDir = `data/csv-to-docs`;
 

--- a/test/fn/csv-to-docs.spec.js
+++ b/test/fn/csv-to-docs.spec.js
@@ -8,6 +8,8 @@ const fs = require('../../src/lib/sync-fs');
 describe('csv-to-docs', function() {
   this.timeout(30000); // allow time for slow things
 
+  sinon.useFakeTimers();
+
   const testDir = `data/csv-to-docs`;
 
   fs.dirs(testDir)

--- a/test/fn/csv-to-docs.spec.js
+++ b/test/fn/csv-to-docs.spec.js
@@ -1,11 +1,11 @@
 const { assert } = require('chai');
 const sinon = require('sinon');
+
+const csvToDocs = require('../../src/fn/csv-to-docs');
 const environment = require('../../src/lib/environment');
 const fs = require('../../src/lib/sync-fs');
 
-let clock = sinon.useFakeTimers();
-
-const csvToDocs = require('../../src/fn/csv-to-docs');
+let clock;
 
 describe('csv-to-docs', function() {
   this.timeout(30000); // allow time for slow things

--- a/test/fn/csv-to-docs.spec.js
+++ b/test/fn/csv-to-docs.spec.js
@@ -1,11 +1,11 @@
 const { assert } = require('chai');
 const sinon = require('sinon');
-
-const csvToDocs = require('../../src/fn/csv-to-docs');
 const environment = require('../../src/lib/environment');
 const fs = require('../../src/lib/sync-fs');
 
-let clock;
+let clock = sinon.useFakeTimers();
+
+const csvToDocs = require('../../src/fn/csv-to-docs');
 
 describe('csv-to-docs', function() {
   this.timeout(30000); // allow time for slow things

--- a/test/fn/csv-to-docs.spec.js
+++ b/test/fn/csv-to-docs.spec.js
@@ -12,6 +12,7 @@ describe('csv-to-docs', function() {
   
   beforeEach(function () {
     clock = sinon.useFakeTimers();
+    csvToDocs.setNOW(new Date().getTime());
   });
 
   afterEach(function () {

--- a/test/fn/csv-to-docs.spec.js
+++ b/test/fn/csv-to-docs.spec.js
@@ -8,7 +8,7 @@ const fs = require('../../src/lib/sync-fs');
 describe('csv-to-docs', function() {
   this.timeout(30000); // allow time for slow things
 
-  sinon.useFakeTimers();
+  sinon.useFakeTimers(0);
 
   const testDir = `data/csv-to-docs`;
 


### PR DESCRIPTION
As requested by @binokaryg we introduce two new types: `rel-date` to input relative dates and `rel-timestamp` to produce relative timestamp. The offset is in number of days from the time when `medic-conf` is executed.

https://github.com/medic/medic-conf/issues/230