### PR TITLE
Remove npm audit check

### DIFF
--- a/.auditrc.json
+++ b/.auditrc.json
@@ -1,7 +1,0 @@
-{
-  "permitted": [
-    "788",
-    "813"
-  ],
-  "verified_hash": "e6935c48f5c7b1cc62dfe3ba13a181c1"
-}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf ./build/",
     "generate-changelog": "echo 'Generating changelog...' && ./scripts/changelog > CHANGELOG.md && echo 'Changelog generated.'",
     "eslint": "eslint src/**/*.js test/*.js test/**/*.js",
-    "test": "npm run eslint && npm run clean && mkdir -p build/test && cp -r test/data build/test/data && cd build/test && mocha ../../test/**/*.spec.js && cd ../.. && npx @medic/audit-dependencies check",
+    "test": "npm run eslint && npm run clean && mkdir -p build/test && cp -r test/data build/test/data && cd build/test && mocha ../../test/**/*.spec.js && cd ../..",
     "postversion": "npm publish",
     "postpublish": "git push --all; git push --tags"
   },


### PR DESCRIPTION
For some reason hashing the package-lock.json is not reliable
and we keep getting false alarms. Instead we're going to
manually run audit and check the results once every release
cycle.

medic/medic#5521