### PR TITLE
Removes all moment locale files with webpack’s IgnorePlugin

### DIFF
--- a/src/lib/package-lib.js
+++ b/src/lib/package-lib.js
@@ -70,7 +70,10 @@ module.exports = (pathToProject, entry, baseEslintPath, options = {}) => {
           },
         },
       ],
-    }
+    },
+    plugins: [
+      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/), // Ignore all optional deps of moment.js
+    ]
   }]);
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
As described here: https://github.com/jmblog/how-to-optimize-momentjs-with-webpack

config/default:
./contact-summary.js  277 KiB
to
./contact-summary.js  67.8 KiB

https://github.com/medic/cht-core/issues/6115
https://github.com/medic/medic-conf/issues/224