### PR TITLE
Tasks and Targets v2 - Declarative configuration update to use new expected schema

### DIFF
--- a/src/lib/compile-nools-rules.js
+++ b/src/lib/compile-nools-rules.js
@@ -45,9 +45,9 @@ const compileDeclarativeFiles = async (projectDir, options) => {
   const baseEslintPath = path.join(__dirname, '../nools/.eslintrc');
   
   const code = await pack(projectDir, pathToDeclarativeLib, baseEslintPath, options);
-  return `define Target { _id: null, deleted: null, type: null, pass: null, date: null }
-define Contact { contact: null, reports: null }
-define Task { _id: null, deleted: null, doc: null, contact: null, icon: null, date: null, title: null, fields: null, resolved: null, priority: null, priorityLabel: null, reports: null, actions: null }
+  return `define Target { _id: null, contact: null, deleted: null, type: null, pass: null, date: null }
+define Contact { contact: null, reports: null, tasks: null }
+define Task { _id: null, deleted: null, doc: null, contact: null, icon: null, date: null, readyStart: null, readyEnd: null, title: null, fields: null, resolved: null, priority: null, priorityLabel: null, reports: null, actions: null }
 rule GenerateEvents {
   when { c: Contact } then { ${code} }
 }`;

--- a/src/nools/target-emitter.js
+++ b/src/nools/target-emitter.js
@@ -42,6 +42,7 @@ function emitTargetFor(targetConfig, Target, Utils, emit, c, r) {
   var pass = !targetConfig.passesIf || !!targetConfig.passesIf(c, r);
   var instance = new Target({
     _id: instanceId + '~' + targetConfig.id,
+    contact: c.contact,
     deleted: !!instanceDoc.deleted,
     type: targetConfig.id,
     pass: pass,

--- a/src/nools/task-emitter.js
+++ b/src/nools/task-emitter.js
@@ -108,6 +108,8 @@ function emitTasks(taskDefinition, Utils, Task, emit, c, r) {
         contact: obtainContactLabelFromSchedule(taskDefinition, c, r),
         icon: taskDefinition.icon,
         date: dueDate,
+        readyStart: event.start || 0,
+        readyEnd: event.end || 0,
         title: taskDefinition.title,
         resolved: taskDefinition.resolvedIf(c, r, event, dueDate, scheduledTaskIdx),
         actions: taskDefinition.actions.map(initActions),


### PR DESCRIPTION
This is an associated change from https://github.com/medic/cht-core/issues/5657. 

The ongoing Task and Target Improvements (Rules-Engine v2) which are happening in the 3.8 release require additional data about each task emitted by partner code. After upgrading to 3.8, the task and analytics tabs won't function until partner code is updated to send this new data.

The data can be included without affecting the behavior of the existing webapp. Therefore, we can make a change now to include the data in declarative partner configurations. The goal is that it won't affect anything in ongoing operations and projects will be able to seemlessly upgrade to 3.8 if they have deployed their configuration with medic-conf >3.1.0