### PR TITLE
Handles 404 from API (can't fetch xml attachment)

### DIFF
--- a/src/lib/upload-forms.js
+++ b/src/lib/upload-forms.js
@@ -62,7 +62,7 @@ module.exports = (projectDir, subDirectory, options) => {
         .then(() => info(`Uploaded form ${formsDir}/${fileName}`))
         .then(() => warnUploadOverwrite.postUploadByXml(doc._id, xml))
         .catch(e => {
-          if (!e.message.includes('No changes')) {
+          if (!e.message || !e.message.includes('No changes')) {
             throw e;
           } else {
             info(`Form ${formsDir}/${fileName} not uploaded, no changes`);

--- a/src/lib/warn-upload-overwrite.js
+++ b/src/lib/warn-upload-overwrite.js
@@ -128,9 +128,10 @@ const preUploadByXml = async (db, docId, localXml) => {
     remoteXml = buffer.toString('utf8');
   } catch (e) {
     if (e.status === 404) {
+      // The form doesn't exist on the server so we know we're not overwriting anything
       return Promise.resolve();
     } else {
-      // continue regardless of error
+      // Unexpected error, we report it then quit
       log.trace('Trying to fetch remote xml', e);
       throw new Error(`Unable to fetch xml attachment of doc with id ${docId}, returned status code = ${e.status}`);
     }

--- a/src/lib/warn-upload-overwrite.js
+++ b/src/lib/warn-upload-overwrite.js
@@ -127,9 +127,13 @@ const preUploadByXml = async (db, docId, localXml) => {
     const buffer = await db.getAttachment(docId, 'xml');
     remoteXml = buffer.toString('utf8');
   } catch (e) {
-    // continue regardless of error
-    log.trace('Trying to fetch remote xml', e);
-    throw e;
+    if (e.status === 404) {
+      return Promise.resolve();
+    } else {
+      // continue regardless of error
+      log.trace('Trying to fetch remote xml', e);
+      throw new Error(`Unable to fetch xml attachment of doc with id ${docId}, returned status code = ${e.status}`);
+    }
   }
 
   const remoteHash = crypto.createHash('md5').update(remoteXml, 'binary').digest('base64');

--- a/test/lib/warn-upload-overwrite.spec.js
+++ b/test/lib/warn-upload-overwrite.spec.js
@@ -1,5 +1,6 @@
 const api = require('../api-stub');
 const assert = require('chai').assert;
+const sinon = require('sinon');
 const fs = require('../../src/lib/sync-fs');
 const readline = require('readline-sync');
 const warnUploadOverwrite = require('../../src/lib/warn-upload-overwrite');
@@ -110,6 +111,19 @@ describe('prompts when attempting to overwrite (by xml)', () => {
     return warnUploadOverwrite.preUploadByXml(api.db, 'x', localXml)
     .catch(e => {
       assert.equal('configuration modified', e.message);
+    });
+  });
+
+  it('uploads the local xml if remote xml does not exist', () => {
+    let error = new Error('No attachment');
+    error.status = 404;
+    api.db.getAttachment = sinon.stub().throws(error);
+    fs.read = () => '{"localhost/medic":"y"}';
+    const localXml = '<?xml version="1.0"?><x />';
+
+    return warnUploadOverwrite.preUploadByXml(api.db, 'x', localXml)
+    .then(() => {
+      assert(api.db.getAttachment.calledOnce);
     });
   });
 


### PR DESCRIPTION
I was able to reproduce this bug. It occurs when the remote form does not exist so we fail to fetch the corresponding xml attachment.

https://github.com/medic/medic-conf/issues/278