### PR TITLE
Move-contact action should support use of contact_type

### DIFF
--- a/src/fn/move-contacts.js
+++ b/src/fn/move-contacts.js
@@ -145,7 +145,7 @@ medic-conf --local move-contacts -- --contactIds=<id1>,<id2> --parent=<parent_id
 
 ${bold('OPTIONS')}
 --contacts=<id1>,<id2>
-  A comma delimited list of ids of ocntacts to be moved.
+  A comma delimited list of ids of contacts to be moved.
 
 --parent=<parent_id>
   Specifies the ID of the new parent. Use '${HIERARCHY_ROOT}' to identify the top of the hierarchy (no parent).

--- a/src/fn/move-contacts.js
+++ b/src/fn/move-contacts.js
@@ -124,7 +124,7 @@ const prepareDocumentDirectory = ({ docDirectoryPath, force }) => {
   if (!fs.exists(docDirectoryPath)) {
     fs.mkdir(docDirectoryPath);
   } else if (!force && fs.recurseFiles(docDirectoryPath).length > 0) {
-    warn(`The document folder '${docDirectoryPath}' already contains files. It is recommended you start with a clean folder. Do you clear this folder and continue?`);
+    warn(`The document folder '${docDirectoryPath}' already contains files. It is recommended you start with a clean folder. Do you want to delete the contents of this folder and continue?`);
     if(readline.keyInYN()) {
       fs.deleteFilesInFolder(docDirectoryPath);
     } else {
@@ -144,7 +144,7 @@ ${bold('USAGE')}
 medic-conf --local move-contacts -- --contactIds=<id1>,<id2> --parent=<parent_id>
 
 ${bold('OPTIONS')}
---contactIds=<id1>,<id2>
+--contacts=<id1>,<id2>
   A comma delimited list of ids of ocntacts to be moved.
 
 --parent=<parent_id>

--- a/src/lib/lineage-constraints.js
+++ b/src/lib/lineage-constraints.js
@@ -42,8 +42,9 @@ Enforce the whitelist of allowed parents for each contact type
 Ensure we are not creating a circular hierarchy
 */
 const getHierarchyViolations = (mapTypeToAllowedParents, contactDoc, parentDoc) => {
-  const { type: contactType } = contactDoc;
-  const parentType = parentDoc && (parentDoc.type === 'contact' ? parentDoc.contact_type : parentDoc.type);
+  const getContactType = doc => doc && (doc.type === 'contact' ? doc.contact_type : doc.type);
+  const contactType = getContactType(contactDoc);
+  const parentType = getContactType(parentDoc);
   if (!contactType) return 'contact required attribute "type" is undefined';
   if (parentDoc && !parentType) return `parent contact "${parentDoc._id}" required attribute "type" is undefined`;
   if (!mapTypeToAllowedParents) return 'hierarchy constraints are undefined';

--- a/src/lib/lineage-constraints.js
+++ b/src/lib/lineage-constraints.js
@@ -43,9 +43,9 @@ Ensure we are not creating a circular hierarchy
 */
 const getHierarchyViolations = (mapTypeToAllowedParents, contactDoc, parentDoc) => {
   const { type: contactType } = contactDoc;
-  const { type: parentType } = parentDoc || {};
+  const parentType = parentDoc && (parentDoc.type === 'contact' ? parentDoc.contact_type : parentDoc.type);
   if (!contactType) return 'contact required attribute "type" is undefined';
-  if (parentDoc && !parentType) return 'parent required attribute "type" is undefined';
+  if (parentDoc && !parentType) return `parent contact "${parentDoc._id}" required attribute "type" is undefined`;
   if (!mapTypeToAllowedParents) return 'hierarchy constraints are undefined';
 
   const rulesForContact = mapTypeToAllowedParents[contactType];

--- a/test/fn/move-contacts.spec.js
+++ b/test/fn/move-contacts.spec.js
@@ -12,7 +12,7 @@ const { mockReport, mockHierarchy, parentsToLineage } = require('../mock-hierarc
 
 const contacts_by_depth = {
   // eslint-disable-next-line quotes
-  map: "function(doc) {\n  if (doc.type === 'tombstone' && doc.tombstone) {\n    doc = doc.tombstone;\n  }\n  if (['person', 'clinic', 'health_center', 'district_hospital'].indexOf(doc.type) !== -1) {\n    var value = doc.patient_id || doc.place_id;\n    var parent = doc;\n    var depth = 0;\n    while (parent) {\n      if (parent._id) {\n        emit([parent._id], value);\n        emit([parent._id, depth], value);\n      }\n      depth++;\n      parent = parent.parent;\n    }\n  }\n}",
+  map: "function(doc) {\n  if (doc.type === 'tombstone' && doc.tombstone) {\n    doc = doc.tombstone;\n  }\n  if (['contact', 'person', 'clinic', 'health_center', 'district_hospital'].indexOf(doc.type) !== -1) {\n    var value = doc.patient_id || doc.place_id;\n    var parent = doc;\n    var depth = 0;\n    while (parent) {\n      if (parent._id) {\n        emit([parent._id], value);\n        emit([parent._id, depth], value);\n      }\n      depth++;\n      parent = parent.parent;\n    }\n  }\n}",
 };
 
 const reports_by_freetext = {
@@ -24,7 +24,7 @@ describe('move-contacts', () => {
 
   let pouchDb, scenarioCount = 0;
   const writtenDocs = [];
-  const getWrittenDoc = async docId => {
+  const getWrittenDoc = docId => {
     const matches = writtenDocs.filter(doc => doc && doc._id === docId);
     if (matches.length === 0) {
       return undefined;
@@ -89,33 +89,33 @@ describe('move-contacts', () => {
       parentId: 'district_2',
     }, pouchDb);
 
-    expect(await getWrittenDoc('health_center_1_contact')).to.deep.eq({
+    expect(getWrittenDoc('health_center_1_contact')).to.deep.eq({
       _id: 'health_center_1_contact',
       type: 'person',
       parent: parentsToLineage('health_center_1', 'district_2'),
     });
 
-    expect(await getWrittenDoc('health_center_1')).to.deep.eq({
+    expect(getWrittenDoc('health_center_1')).to.deep.eq({
       _id: 'health_center_1',
       type: 'health_center',
       contact: parentsToLineage('health_center_1_contact', 'health_center_1', 'district_2'),
       parent: parentsToLineage('district_2'),
     });
 
-    expect(await getWrittenDoc('clinic_1')).to.deep.eq({
+    expect(getWrittenDoc('clinic_1')).to.deep.eq({
       _id: 'clinic_1',
       type: 'clinic',
       contact: parentsToLineage('clinic_1_contact', 'clinic_1', 'health_center_1', 'district_2'),
       parent: parentsToLineage('health_center_1', 'district_2'),
     });
 
-    expect(await getWrittenDoc('patient_1')).to.deep.eq({
+    expect(getWrittenDoc('patient_1')).to.deep.eq({
       _id: 'patient_1',
       type: 'person',
       parent: parentsToLineage('clinic_1', 'health_center_1', 'district_2'),
     });
 
-    expect(await getWrittenDoc('report_1')).to.deep.eq({
+    expect(getWrittenDoc('report_1')).to.deep.eq({
       _id: 'report_1',
       form: 'foo',
       type: 'data_record',
@@ -131,33 +131,33 @@ describe('move-contacts', () => {
       parentId: 'root',
     }, pouchDb);
 
-    expect(await getWrittenDoc('health_center_1_contact')).to.deep.eq({
+    expect(getWrittenDoc('health_center_1_contact')).to.deep.eq({
       _id: 'health_center_1_contact',
       type: 'person',
       parent: parentsToLineage('health_center_1'),
     });
 
-    expect(await getWrittenDoc('health_center_1')).to.deep.eq({
+    expect(getWrittenDoc('health_center_1')).to.deep.eq({
       _id: 'health_center_1',
       type: 'health_center',
       contact: parentsToLineage('health_center_1_contact', 'health_center_1'),
       parent: parentsToLineage(),
     });
 
-    expect(await getWrittenDoc('clinic_1')).to.deep.eq({
+    expect(getWrittenDoc('clinic_1')).to.deep.eq({
       _id: 'clinic_1',
       type: 'clinic',
       contact: parentsToLineage('clinic_1_contact', 'clinic_1', 'health_center_1'),
       parent: parentsToLineage('health_center_1'),
     });
 
-    expect(await getWrittenDoc('patient_1')).to.deep.eq({
+    expect(getWrittenDoc('patient_1')).to.deep.eq({
       _id: 'patient_1',
       type: 'person',
       parent: parentsToLineage('clinic_1', 'health_center_1'),
     });
 
-    expect(await getWrittenDoc('report_1')).to.deep.eq({
+    expect(getWrittenDoc('report_1')).to.deep.eq({
       _id: 'report_1',
       form: 'foo',
       type: 'data_record',
@@ -173,40 +173,40 @@ describe('move-contacts', () => {
       parentId: 'district_2',
     }, pouchDb);
 
-    expect(await getWrittenDoc('district_1')).to.deep.eq({
+    expect(getWrittenDoc('district_1')).to.deep.eq({
       _id: 'district_1',
       type: 'district_hospital',
       contact: parentsToLineage('district_1_contact', 'district_1', 'district_2'),
       parent: parentsToLineage('district_2'),
     });
 
-    expect(await getWrittenDoc('health_center_1_contact')).to.deep.eq({
+    expect(getWrittenDoc('health_center_1_contact')).to.deep.eq({
       _id: 'health_center_1_contact',
       type: 'person',
       parent: parentsToLineage('health_center_1', 'district_1', 'district_2'),
     });
 
-    expect(await getWrittenDoc('health_center_1')).to.deep.eq({
+    expect(getWrittenDoc('health_center_1')).to.deep.eq({
       _id: 'health_center_1',
       type: 'health_center',
       contact: parentsToLineage('health_center_1_contact', 'health_center_1', 'district_1', 'district_2'),
       parent: parentsToLineage('district_1', 'district_2'),
     });
 
-    expect(await getWrittenDoc('clinic_1')).to.deep.eq({
+    expect(getWrittenDoc('clinic_1')).to.deep.eq({
       _id: 'clinic_1',
       type: 'clinic',
       contact: parentsToLineage('clinic_1_contact', 'clinic_1', 'health_center_1', 'district_1', 'district_2'),
       parent: parentsToLineage('health_center_1', 'district_1', 'district_2'),
     });
 
-    expect(await getWrittenDoc('patient_1')).to.deep.eq({
+    expect(getWrittenDoc('patient_1')).to.deep.eq({
       _id: 'patient_1',
       type: 'person',
       parent: parentsToLineage('clinic_1', 'health_center_1', 'district_1', 'district_2'),
     });
 
-    expect(await getWrittenDoc('report_1')).to.deep.eq({
+    expect(getWrittenDoc('report_1')).to.deep.eq({
       _id: 'report_1',
       form: 'foo',
       type: 'data_record',
@@ -214,7 +214,7 @@ describe('move-contacts', () => {
     });
   });
 
-  it('move district_1 to flexible hierarchy root type', async () => {
+  it('move district_1 to flexible hierarchy parent', async () => {
     await pouchDb.put({
       _id: `county_1`,
       type: 'contact',
@@ -231,37 +231,75 @@ describe('move-contacts', () => {
       parentId: 'county_1',
     }, pouchDb);
 
-    expect(await getWrittenDoc('health_center_1_contact')).to.deep.eq({
+    expect(getWrittenDoc('health_center_1_contact')).to.deep.eq({
       _id: 'health_center_1_contact',
       type: 'person',
       parent: parentsToLineage('health_center_1', 'district_1', 'county_1'),
     });
 
-    expect(await getWrittenDoc('health_center_1')).to.deep.eq({
+    expect(getWrittenDoc('health_center_1')).to.deep.eq({
       _id: 'health_center_1',
       type: 'health_center',
       contact: parentsToLineage('health_center_1_contact', 'health_center_1', 'district_1', 'county_1'),
       parent: parentsToLineage('district_1', 'county_1'),
     });
 
-    expect(await getWrittenDoc('clinic_1')).to.deep.eq({
+    expect(getWrittenDoc('clinic_1')).to.deep.eq({
       _id: 'clinic_1',
       type: 'clinic',
       contact: parentsToLineage('clinic_1_contact', 'clinic_1', 'health_center_1', 'district_1', 'county_1'),
       parent: parentsToLineage('health_center_1', 'district_1', 'county_1'),
     });
 
-    expect(await getWrittenDoc('patient_1')).to.deep.eq({
+    expect(getWrittenDoc('patient_1')).to.deep.eq({
       _id: 'patient_1',
       type: 'person',
       parent: parentsToLineage('clinic_1', 'health_center_1', 'district_1', 'county_1'),
     });
 
-    expect(await getWrittenDoc('report_1')).to.deep.eq({
+    expect(getWrittenDoc('report_1')).to.deep.eq({
       _id: 'report_1',
       form: 'foo',
       type: 'data_record',
       contact: parentsToLineage('health_center_1_contact', 'health_center_1', 'district_1', 'county_1'),
+    });
+  });
+
+  it('moves flexible hierarchy contact to flexible hierarchy parent', async () => {
+    await updateHierarchyRules([
+      { id: 'county', parents: [] },
+      { id: 'subcounty', parents: ['county'] },
+      { id: 'focal', parents: ['county', 'subcounty'], person: true }
+    ]);
+
+    await pouchDb.bulkDocs([
+      { _id: `county`, type: 'contact', contact_type: 'county' },
+      { _id: `subcounty`, type: 'contact', contact_type: 'subcounty', parent: { _id: 'county' } },
+      { _id: `focal`, type: 'contact', contact_type: 'focal', parent: { _id: 'county' } },
+    ]);
+
+    await mockReport(pouchDb, {
+      id: 'report_focal',
+      creatorId: 'focal',
+    });
+    
+    await updateLineagesAndStage({
+      contactIds: ['focal'],
+      parentId: 'subcounty',
+    }, pouchDb);
+
+    expect(getWrittenDoc('focal')).to.deep.eq({
+      _id: 'focal',
+      type: 'contact',
+      contact_type: 'focal',
+      parent: parentsToLineage('subcounty', 'county'),
+    });
+
+    expect(getWrittenDoc('report_focal')).to.deep.eq({
+      _id: 'report_focal',
+      form: 'foo',
+      type: 'data_record',
+      contact: parentsToLineage('focal', 'subcounty', 'county'),
     });
   });
 
@@ -297,14 +335,14 @@ describe('move-contacts', () => {
       parentId: 't_clinic_2',
     }, pouchDb);
 
-    expect(await getWrittenDoc('t_health_center_1')).to.deep.eq({
+    expect(getWrittenDoc('t_health_center_1')).to.deep.eq({
       _id: 't_health_center_1',
       type: 'health_center',
       contact: parentsToLineage('t_patient_1', 't_clinic_2', 't_health_center_1', 't_district_1'),
       parent: parentsToLineage('t_district_1'),
     });
 
-    expect(await getWrittenDoc('t_district_1')).to.deep.eq({
+    expect(getWrittenDoc('t_district_1')).to.deep.eq({
       _id: 't_district_1',
       type: 'district_hospital',
       contact: parentsToLineage('t_patient_1', 't_clinic_2', 't_health_center_1', 't_district_1'),
@@ -321,7 +359,7 @@ describe('move-contacts', () => {
       parentId: 'district_2',
     }, pouchDb);
 
-    expect(await getWrittenDoc('health_center_1')).to.deep.eq({
+    expect(getWrittenDoc('health_center_1')).to.deep.eq({
       _id: 'health_center_1',
       type: 'health_center',
       contact: parentsToLineage('health_center_1_contact', 'health_center_1', 'district_2'),
@@ -353,13 +391,13 @@ describe('move-contacts', () => {
     }, pouchDb);
 
 
-    expect(await getWrittenDoc('clinic_1')).to.deep.eq({
+    expect(getWrittenDoc('clinic_1')).to.deep.eq({
       _id: 'clinic_1',
       type: 'clinic',
       important: true,
       parent: parentsToLineage('district_2'),
     });
-    expect(await getWrittenDoc('patient_1')).to.deep.eq({
+    expect(getWrittenDoc('patient_1')).to.deep.eq({
       _id: 'patient_1',
       type: 'person',
       important: true,


### PR DESCRIPTION
Add support for executing the `move-contacts` action when the parent is configured using the `contact_type` attribute (flexible hierarchy).

#286 