### PR TITLE
288 - medic-conf version check

### DIFF
--- a/src/lib/check-medic-conf-dependency-version.js
+++ b/src/lib/check-medic-conf-dependency-version.js
@@ -1,16 +1,11 @@
 /**
  * Attempt to check that the version of medic-conf that a project relies on
  * matches the version of medic-conf being used to configure that project.
- *
- * Currently this check is only performed as part of app-settings compilation;
- * if required in more places then we might move the check to the main CLI
- * script.
- * Is this second part true?
  */
 
 const fs = require('./sync-fs');
 const semver = require('semver');
-const { warn} = require('./log');
+const {warn} = require('./log');
 
 const runningVersion = require('../../package.json').version;
 

--- a/src/lib/check-medic-conf-dependency-version.js
+++ b/src/lib/check-medic-conf-dependency-version.js
@@ -19,20 +19,23 @@ module.exports = projectDir => {
   const majorRunningVersion = semver.major(runningVersion);
   let upgradeDowngradeLocalMsg = '';
   let upgradeDowngradeProjectMsg = '';
-  if(semver.satisfies(projectVersion, `<${majorRunningVersion}.x || >${runningVersion}`)) {
+  let satisfiesLessThanMajorRunningVersion = semver.satisfies(projectVersion, `<${majorRunningVersion}.x`);
+  let satisifiesGreaterThanRunningVersion = semver.satisfies(projectVersion, `>${runningVersion}`);
+
+  if(satisfiesLessThanMajorRunningVersion || satisifiesGreaterThanRunningVersion) {
     
-    if(semver.satisfies(projectVersion, `<${majorRunningVersion}.x`)) {
+    if(satisfiesLessThanMajorRunningVersion) {
       upgradeDowngradeLocalMsg = 'Downgrade';
-      upgradeDowngradeProjectMsg = 'Update';
+      upgradeDowngradeProjectMsg = 'update';
     }
-    else if(semver.satisfies(projectVersion, `>${runningVersion}`))
+    else if(satisifiesGreaterThanRunningVersion)
     {
       upgradeDowngradeLocalMsg = 'Upgrade';
       upgradeDowngradeProjectMsg = 'downgrade';
     }
 
     throw new Error(`Your medic-conf version is incompatible with the project's medic-conf version:
-    Your local medi-conf version:   ${runningVersion}
+    Your local medic-conf version:   ${runningVersion}
     The project medic-conf version: ${projectVersion}
     
     Continuing without updating could cause this project to not compile or work as expected.

--- a/src/lib/check-medic-conf-dependency-version.js
+++ b/src/lib/check-medic-conf-dependency-version.js
@@ -18,7 +18,17 @@ module.exports = projectDir => {
 
   const majorRunningVersion = semver.major(runningVersion);
   if(semver.satisfies(projectVersion, `<${majorRunningVersion}.x || >${runningVersion}`)) {
-    throw new Error(`medic-conf version ${runningVersion} does not match the project's required version: ${projectVersion}. To ignore this error, use --skip-dependency-check.`);
+    throw new Error(`Your medic-conf version is incompatible with the project's medic-conf version:
+    Yours:  ${runningVersion}
+    Theirs: ${projectVersion}
+    
+    Continuing without updating could cause this project to not compile or work as expected.
+    
+    Update your local medic-conf with:
+     npm i -g medic-conf@${projectVersion}
+    and try again, or update the project to your current version, or ignore this warning with --skip-dependency-check
+    `);
+  
   }
 };
 

--- a/src/lib/check-medic-conf-dependency-version.js
+++ b/src/lib/check-medic-conf-dependency-version.js
@@ -5,7 +5,7 @@
 
 const fs = require('./sync-fs');
 const semver = require('semver');
-const {warn} = require('./log');
+const { warn } = require('./log');
 
 const runningVersion = require('../../package.json').version;
 

--- a/src/lib/check-medic-conf-dependency-version.js
+++ b/src/lib/check-medic-conf-dependency-version.js
@@ -17,16 +17,29 @@ module.exports = projectDir => {
   }
 
   const majorRunningVersion = semver.major(runningVersion);
+  let upgradeDowngradeLocalMsg = '';
+  let upgradeDowngradeProjectMsg = '';
   if(semver.satisfies(projectVersion, `<${majorRunningVersion}.x || >${runningVersion}`)) {
+    
+    if(semver.satisfies(projectVersion, `<${majorRunningVersion}.x`)) {
+      upgradeDowngradeLocalMsg = 'Downgrade';
+      upgradeDowngradeProjectMsg = 'Update';
+    }
+    else if(semver.satisfies(projectVersion, `>${runningVersion}`))
+    {
+      upgradeDowngradeLocalMsg = 'Upgrade';
+      upgradeDowngradeProjectMsg = 'downgrade';
+    }
+
     throw new Error(`Your medic-conf version is incompatible with the project's medic-conf version:
-    Yours:  ${runningVersion}
-    Theirs: ${projectVersion}
+    Your local medi-conf version:   ${runningVersion}
+    The project medic-conf version: ${projectVersion}
     
     Continuing without updating could cause this project to not compile or work as expected.
     
-    Update your local medic-conf with:
-     npm i -g medic-conf@${projectVersion}
-    and try again, or update the project to your current version, or ignore this warning with --skip-dependency-check
+    ${upgradeDowngradeLocalMsg} your local medic-conf with:
+        npm i -g medic-conf@${projectVersion}
+    and try again, or ${upgradeDowngradeProjectMsg} the project medic-conf version to ${runningVersion}, or ignore this warning with --skip-dependency-check
     `);
   
   }

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -1,7 +1,4 @@
-#!/usr/bin/env node
-
 const open = require('open');
-
 const checkForUpdates = require('../lib/check-for-updates');
 const checkMedicConfDependencyVersion = require('../lib/check-medic-conf-dependency-version');
 const environment = require('./environment');

--- a/test/lib/check-medic-conf-dependency-version.spec.js
+++ b/test/lib/check-medic-conf-dependency-version.spec.js
@@ -1,8 +1,6 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const rewire = require('rewire');
-//const fs = require('../../src/lib/sync-fs');
-//const { warn} = require('../../src/lib/log');
 
 const projectDir = rewire('../../src/lib/check-medic-conf-dependency-version');
 

--- a/test/lib/check-medic-conf-dependency-version.spec.js
+++ b/test/lib/check-medic-conf-dependency-version.spec.js
@@ -1,0 +1,68 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const rewire = require('rewire');
+//const fs = require('../../src/lib/sync-fs');
+//const { warn} = require('../../src/lib/log');
+
+const projectDir = rewire('../../src/lib/check-medic-conf-dependency-version');
+
+describe('test different medic-conf versions', () => { 
+  let warn, fs; 
+  
+  beforeEach(() => {
+    const runningVersion = '3.1.2';
+  
+    warn = sinon.stub();
+    fs = {
+      exists: sinon.stub().returns(true),
+      readJson: sinon.stub().returns({ dependencies: { 'medic-conf': '1.0.0' } }),
+    };
+
+    projectDir.__set__('warn', warn);
+    projectDir.__set__('runningVersion', runningVersion);
+    projectDir.__set__('fs', fs);
+  });
+
+  const scenarios = [
+    { version: '2.0.0', throw: true },
+    { version: '3.0.0' },
+        
+    { version: '3.1.1' },
+    { version: '3.1.2' },
+    { version: '3.1.3', throw: true },
+    { version: '3.2.0', throw: true },
+
+    { desc: 'undefined', version: undefined, warn: true },
+    { desc: 'empty', version: '', warn: true },
+    { version: '3.3.0', throw: true },
+    { version: '4.0.0', throw: true },
+    { version: '4.1.0', throw: true },
+    { version: '4.0.1', throw: true },
+    { version: '5.0.0', throw: true },
+  ];
+
+  for (const scenario of scenarios) {
+    it(`${scenario.desc || scenario.version}`, () => {
+      fs.readJson.returns({ dependencies: { 'medic-conf': scenario.version } });
+
+      if (scenario.throw) {
+        expect(() => projectDir('fake')).to.throw();
+      } else {
+        const actual = projectDir('fake');
+        expect(actual).to.be.undefined;
+      }
+      expect(warn.called).to.eq(!!scenario.warn);
+    });
+  }
+
+  it('project package.json path does not exist', () => {
+    fs.exists.returns(false);
+    const actual = projectDir('fake');
+    expect(actual).to.be.undefined;
+    expect(warn.args[0][0]).to.include('No project package.json');
+  });
+
+  it('devDependencies', () => {
+    
+  });
+});

--- a/test/lib/check-medic-conf-dependency-version.spec.js
+++ b/test/lib/check-medic-conf-dependency-version.spec.js
@@ -2,41 +2,38 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const rewire = require('rewire');
 
-const projectDir = rewire('../../src/lib/check-medic-conf-dependency-version');
+const checkMedicConfVersion = rewire('../../src/lib/check-medic-conf-dependency-version');
+const RUNNING_VERSION = '3.1.2';
 
-describe('test different medic-conf versions', () => { 
+describe('check-medic-conf-dependency-version', () => { 
   let warn, fs; 
   
-  beforeEach(() => {
-    const runningVersion = '3.1.2';
-  
+  beforeEach(() => {  
     warn = sinon.stub();
     fs = {
       exists: sinon.stub().returns(true),
       readJson: sinon.stub().returns({ dependencies: { 'medic-conf': '1.0.0' } }),
     };
 
-    projectDir.__set__('warn', warn);
-    projectDir.__set__('runningVersion', runningVersion);
-    projectDir.__set__('fs', fs);
+    checkMedicConfVersion.__set__('warn', warn);
+    checkMedicConfVersion.__set__('runningVersion', RUNNING_VERSION);
+    checkMedicConfVersion.__set__('fs', fs);
   });
 
   const scenarios = [
     { version: '2.0.0', throw: true },
-    { version: '3.0.0' },
-        
+    { version: '3.0.0' },    
     { version: '3.1.1' },
     { version: '3.1.2' },
     { version: '3.1.3', throw: true },
     { version: '3.2.0', throw: true },
-
-    { desc: 'undefined', version: undefined, warn: true },
-    { desc: 'empty', version: '', warn: true },
     { version: '3.3.0', throw: true },
     { version: '4.0.0', throw: true },
     { version: '4.1.0', throw: true },
     { version: '4.0.1', throw: true },
     { version: '5.0.0', throw: true },
+    { desc: 'undefined', version: undefined, warn: true },
+    { desc: 'empty', version: '', warn: true }
   ];
 
   for (const scenario of scenarios) {
@@ -44,9 +41,9 @@ describe('test different medic-conf versions', () => {
       fs.readJson.returns({ dependencies: { 'medic-conf': scenario.version } });
 
       if (scenario.throw) {
-        expect(() => projectDir('fake')).to.throw();
+        expect(() => checkMedicConfVersion()).to.throw();
       } else {
-        const actual = projectDir('fake');
+        const actual = checkMedicConfVersion();
         expect(actual).to.be.undefined;
       }
       expect(warn.called).to.eq(!!scenario.warn);
@@ -55,12 +52,15 @@ describe('test different medic-conf versions', () => {
 
   it('project package.json path does not exist', () => {
     fs.exists.returns(false);
-    const actual = projectDir('fake');
+    const actual = checkMedicConfVersion();
     expect(actual).to.be.undefined;
     expect(warn.args[0][0]).to.include('No project package.json');
   });
 
   it('devDependencies', () => {
-    
-  });
+      fs.readJson.returns({devDependencies:   {'medic-conf': '3.1.2'}});
+      const actual = checkMedicConfVersion();
+      expect(actual).to.be.undefined;
+      expect(warn.called).to.eq(false);
+    });
 });


### PR DESCRIPTION
REF #288 

So the rules for medic-conf version checking.:
 - Newer medic-conf is ok as long as in the same Major version. No warning. So if medic-conf version is `3.1.2`, project version can be `3.0.0 - 3.1.2`
- Major version differing should always give an error. A suggestion to use `--skip-dependency-check` is given.