### PR TITLE
Remove shebang - causes Travis tests to fail on Node.JS version 12

### DIFF
--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 const open = require('open');
 
 const checkForUpdates = require('../lib/check-for-updates');


### PR DESCRIPTION
This PR removes shebang on  this [line](https://github.com/medic/medic-conf/blob/master/src/lib/main.js#L1) that causes [Travis tests](https://travis-ci.org/medic/medic-conf/jobs/652976540?utm_medium=notification&utm_source=github_status) to fail on NodeJS version 12. 
 cc @SCdF 