### PR TITLE
Check all form attributes when looking for change

### DIFF
--- a/src/fn/upload-custom-translations.js
+++ b/src/fn/upload-custom-translations.js
@@ -53,12 +53,16 @@ const execute = async () => {
 
     overwriteProperties(doc, translations);
 
-    await warnUploadOverwrite.preUploadByRev(db, doc);
+    const changes = await warnUploadOverwrite.preUploadDoc(db, doc);
 
-    info(`Uploaded translation ${dir}/${fileName}`);
-    await db.put(doc);
+    if (changes) {
+      await db.put(doc);
+      info(`Translation ${dir}/${fileName} uploaded`);
+    } else {
+      info(`Translation ${dir}/${fileName} not uploaded as no changes were found`);
+    }
 
-    await warnUploadOverwrite.postUploadByRev(db, doc);
+    warnUploadOverwrite.postUploadDoc(doc);
   }
 };
 

--- a/src/fn/upload-resources.js
+++ b/src/fn/upload-resources.js
@@ -2,7 +2,7 @@ const attachmentsFromDir = require('../lib/attachments-from-dir');
 const environment = require('../lib/environment');
 const fs = require('../lib/sync-fs');
 const pouch = require('../lib/db');
-const { warn } = require('../lib/log');
+const { info, warn } = require('../lib/log');
 const insertOrReplace = require('../lib/insert-or-replace');
 const warnUploadOverwrite = require('../lib/warn-upload-overwrite');
 
@@ -24,11 +24,15 @@ module.exports = {
 
     const db = pouch();
 
-    await warnUploadOverwrite.preUploadByRev(db, doc);
+    const changes = await warnUploadOverwrite.preUploadDoc(db, doc);
+    if (changes) {
+      await insertOrReplace(db, doc);
+      info('Resources file uploaded');
+    } else {
+      info('Resources file not uploaded as no changes found');
+    }
 
-    await insertOrReplace(db, doc);
-
-    await warnUploadOverwrite.postUploadByRev(db, doc);
+    warnUploadOverwrite.postUploadDoc(doc);
 
     return Promise.resolve();
   }

--- a/src/lib/upload-forms.js
+++ b/src/lib/upload-forms.js
@@ -3,12 +3,12 @@ const argsFormFilter = require('./args-form-filter');
 const attachmentsFromDir = require('./attachments-from-dir');
 const attachmentFromFile = require('./attachment-from-file');
 const fs = require('./sync-fs');
-const { info, warn } = require('./log');
+const log = require('./log');
 const insertOrReplace = require('./insert-or-replace');
 const pouch = require('./db');
 const warnUploadOverwrite = require('./warn-upload-overwrite');
 
-const SUPPORTED_PROPERTIES = ['context', 'icon', 'internalId', 'title'];
+const SUPPORTED_PROPERTIES = ['context', 'icon', 'title', 'xml2sms'];
 
 module.exports = (projectDir, subDirectory, options) => {
   const db = pouch();
@@ -16,20 +16,20 @@ module.exports = (projectDir, subDirectory, options) => {
 
   const formsDir = `${projectDir}/forms/${subDirectory}`;
   if(!fs.exists(formsDir)) {
-    warn(`Forms dir not found: ${formsDir}`);
+    log.warn(`Forms dir not found: ${formsDir}`);
     return Promise.resolve();
   }
 
   return argsFormFilter(formsDir, '.xml', options)
     .reduce((promiseChain, fileName) => {
-      info(`Preparing form for upload: ${fileName}…`);
+      log.info(`Preparing form for upload: ${fileName}…`);
 
       const baseFileName = fs.withoutExtension(fileName);
       const mediaDir = `${formsDir}/${baseFileName}-media`;
       const xformPath = `${formsDir}/${baseFileName}.xml`;
       const baseDocId = (options.id_prefix || '') + baseFileName.replace(/-/g, ':');
 
-      if(!fs.exists(mediaDir)) info(`No media directory found at ${mediaDir} for form ${xformPath}`);
+      if(!fs.exists(mediaDir)) log.info(`No media directory found at ${mediaDir} for form ${xformPath}`);
 
       const xml = fs.read(xformPath);
 
@@ -39,7 +39,7 @@ module.exports = (projectDir, subDirectory, options) => {
       }
 
       const internalId = readIdFrom(xml);
-      if(internalId !== baseDocId) warn('DEPRECATED', 'Form:', fileName, 'Bad ID set in XML.  Expected:', baseDocId, 'but saw:', internalId, ' Support for setting these values differently will be dropped.  Please see https://github.com/medic/medic-webapp/issues/3342.');
+      if(internalId !== baseDocId) log.warn('DEPRECATED', 'Form:', fileName, 'Bad ID set in XML.  Expected:', baseDocId, 'but saw:', internalId, ' Support for setting these values differently will be dropped.  Please see https://github.com/medic/medic-webapp/issues/3342.');
 
       const docId = `form:${baseDocId}`;
       const doc = {
@@ -56,18 +56,20 @@ module.exports = (projectDir, subDirectory, options) => {
       doc._attachments = fs.exists(mediaDir) ? attachmentsFromDir(mediaDir) : {};
       doc._attachments.xml = attachmentFromFile(xformPath);
 
+      const properties = SUPPORTED_PROPERTIES.concat('internalId');
+
       return promiseChain
-        .then(() => warnUploadOverwrite.preUploadForm(db, doc, xml))
+        .then(() => warnUploadOverwrite.preUploadForm(db, doc, xml, properties))
         .then(changes => {
           if (changes) {
             return insertOrReplace(db, doc)
-              .then(() => info(`Form ${formsDir}/${fileName} uploaded`));
+              .then(() => log.info(`Form ${formsDir}/${fileName} uploaded`));
           } else {
-            info(`Form ${formsDir}/${fileName} not uploaded, no changes`);
+            log.info(`Form ${formsDir}/${fileName} not uploaded, no changes`);
           }
         })
         // update hash regardless
-        .then(() => warnUploadOverwrite.postUploadForm(doc, xml));
+        .then(() => warnUploadOverwrite.postUploadForm(doc, xml, properties));
     }, Promise.resolve());
 };
 
@@ -81,20 +83,27 @@ const readIdFrom = xml =>
        .match(/id="([^"]*)"/)[1];
 
 const updateFromPropertiesFile = (doc, path) => {
-  if(fs.exists(path)) {
+  if (fs.exists(path)) {
+
+    let ignoredKeys = [];
     const properties = fs.readJson(path);
 
-    if(typeof properties.context !== 'undefined') doc.context = properties.context;
-    doc.icon = properties.icon;
-    if(properties.title) doc.title = properties.title;
+    Object.keys(properties).forEach(key => {
+      if (typeof properties[key] !== 'undefined') {
+        if (SUPPORTED_PROPERTIES.includes(key)) {
+          doc[key] = properties[key];
+        } else if (key === 'internalId') {
+          log.warn(`DEPRECATED: ${path}. Please do not manually set internalId in .properties.json for new projects. Support for configuring this value will be dropped. Please see https://github.com/medic/medic-webapp/issues/3342.`);
+          doc.internalId = properties.internalId;
+        } else {
+          ignoredKeys.push(key);
+        }
+      }
+    });
 
-    if(properties.internalId) {
-      warn('DEPRECATED', path, 'Please do not manually set internalId in .properties.json for new projects.  Support for configuring this value will be dropped.  Please see https://github.com/medic/medic-webapp/issues/3342.');
-      doc.internalId = properties.internalId;
+    if (ignoredKeys.length) {
+      log.warn(`Ignoring unknown properties in ${path}: ${ignoredKeys.join(', ')}`);
     }
-
-    const ignoredKeys = Object.keys(properties).filter(k => !SUPPORTED_PROPERTIES.includes(k));
-    if(ignoredKeys.length) warn('Ignoring property keys', ignoredKeys, 'in', path);
   }
 };
 

--- a/src/lib/upload-forms.js
+++ b/src/lib/upload-forms.js
@@ -57,10 +57,10 @@ module.exports = (projectDir, subDirectory, options) => {
       doc._attachments.xml = attachmentFromFile(xformPath);
 
       return promiseChain
-        .then(() => warnUploadOverwrite.preUploadByXml(db, doc._id, xml))
+        .then(() => warnUploadOverwrite.preUploadByXml(db, doc, xml))
         .then(() => insertOrReplace(db, doc))
         .then(() => info(`Uploaded form ${formsDir}/${fileName}`))
-        .then(() => warnUploadOverwrite.postUploadByXml(doc._id, xml))
+        .then(() => warnUploadOverwrite.postUploadByXml(doc, xml))
         .catch(e => {
           if (!e.message || !e.message.includes('No changes')) {
             throw e;

--- a/src/lib/upload-forms.js
+++ b/src/lib/upload-forms.js
@@ -57,17 +57,17 @@ module.exports = (projectDir, subDirectory, options) => {
       doc._attachments.xml = attachmentFromFile(xformPath);
 
       return promiseChain
-        .then(() => warnUploadOverwrite.preUploadByXml(db, doc, xml))
-        .then(() => insertOrReplace(db, doc))
-        .then(() => info(`Uploaded form ${formsDir}/${fileName}`))
-        .then(() => warnUploadOverwrite.postUploadByXml(doc, xml))
-        .catch(e => {
-          if (!e.message || !e.message.includes('No changes')) {
-            throw e;
+        .then(() => warnUploadOverwrite.preUploadForm(db, doc, xml))
+        .then(changes => {
+          if (changes) {
+            return insertOrReplace(db, doc)
+              .then(() => info(`Form ${formsDir}/${fileName} uploaded`));
           } else {
             info(`Form ${formsDir}/${fileName} not uploaded, no changes`);
           }
-        });
+        })
+        // update hash regardless
+        .then(() => warnUploadOverwrite.postUploadForm(doc, xml));
     }, Promise.resolve());
 };
 

--- a/test/data/lib/upload-forms/merge-properties/forms/example.properties.json
+++ b/test/data/lib/upload-forms/merge-properties/forms/example.properties.json
@@ -1,0 +1,10 @@
+{
+	"icon": "example",
+	"context": {
+		"person": true,
+		"place": false
+	},
+  "xml2sms": "hello world",
+  "internalId": "different",
+  "unknown": true
+}

--- a/test/data/lib/upload-forms/merge-properties/forms/example.xml
+++ b/test/data/lib/upload-forms/merge-properties/forms/example.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+	<h:head>
+		<h:title>Merge properties</h:title>
+		<model>
+			<instance>
+				<data id="example" version="2015-06-05">
+					<name/>
+				</data>
+        <meta>
+          <instanceID/>
+        </meta>
+			</instance>
+			<bind nodeset="/data/name" type="string" />
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/name">
+			<label>What is the name?</label>
+		</input>
+	</h:body>
+</h:html>

--- a/test/lib/upload-forms.spec.js
+++ b/test/lib/upload-forms.spec.js
@@ -2,13 +2,19 @@ const { assert, expect } = require('chai');
 const rewire = require('rewire');
 const sinon = require('sinon');
 
+const api = require('../api-stub');
 const environment = require('../../src/lib/environment');
 const uploadForms = rewire('../../src/lib/upload-forms');
+const log = require('../../src/lib/log');
 
 const BASE_DIR = 'data/lib/upload-forms';
 const FORMS_SUBDIR = '.';
 
 describe('upload-forms', () => {
+
+  beforeEach(api.start);
+  afterEach(api.stop);
+
   it('should reject forms which do not have <meta><instanceID/></meta>', () => {
     sinon.stub(environment, 'apiUrl').get(() => 'http://example.com/db-name');
     // when
@@ -28,4 +34,25 @@ describe('upload-forms', () => {
       expect(insertOrReplace.called).to.be.false;
     });
   });
+
+  it('should merge supported properties into form', () => {
+    const logWarn = sinon.spy(log, 'warn');
+    // when
+    return uploadForms(`${BASE_DIR}/merge-properties`, FORMS_SUBDIR)
+      .then(() => {
+        expect(logWarn.callCount).to.equal(2);
+        expect(logWarn.args[0][0]).to.equal('DEPRECATED: data/lib/upload-forms/merge-properties/forms/./example.properties.json. Please do not manually set internalId in .properties.json for new projects. Support for configuring this value will be dropped. Please see https://github.com/medic/medic-webapp/issues/3342.');
+        expect(logWarn.args[1][0]).to.equal('Ignoring unknown properties in data/lib/upload-forms/merge-properties/forms/./example.properties.json: unknown');
+      })
+      .then(() => api.db.get('form:example'))
+      .then(form => {
+        expect(form.type).to.equal('form');
+        expect(form.internalId).to.equal('different');
+        expect(form.title).to.equal('Merge properties');
+        expect(form.context).to.deep.equal({ person: true, place: false });
+        expect(form.icon).to.equal('example');
+        expect(form.xml2sms).to.equal('hello world');
+      });
+  });
+
 });

--- a/test/lib/warn-upload-overwrite.spec.js
+++ b/test/lib/warn-upload-overwrite.spec.js
@@ -1,9 +1,12 @@
-const api = require('../api-stub');
-const assert = require('chai').assert;
 const sinon = require('sinon');
+const rewire = require('rewire');
+const { assert, expect } = require('chai');
+
+const environment = require('../../src/lib/environment');
+const api = require('../api-stub');
 const fs = require('../../src/lib/sync-fs');
 const readline = require('readline-sync');
-const warnUploadOverwrite = require('../../src/lib/warn-upload-overwrite');
+const warnUploadOverwrite = rewire('../../src/lib/warn-upload-overwrite');
 const log = require('../../src/lib/log');
 
 let calls;
@@ -22,6 +25,89 @@ describe('warn-upload-overwrite', () => {
   afterEach(() => {
     sinon.restore();
     api.stop();
+  });
+
+  describe('getStoredHash', () => {
+
+    it('handles missing dir', () => {
+      fs.exists
+        .onCall(0).returns(false)
+        .onCall(1).returns(false);
+      sinon.stub(fs, 'mkdir').returns();
+      sinon.stub(environment, 'apiUrl').get(() => 'http://a.com');
+      const actual = warnUploadOverwrite.__get__('getStoredHash')('someid');
+      expect(fs.mkdir.callCount).to.equal(1);
+      expect(actual).to.equal(undefined);
+    });
+
+    it('handles missing file', () => {
+      fs.exists
+        .onCall(0).returns(true)
+        .onCall(1).returns(false);
+      sinon.stub(environment, 'apiUrl').get(() => 'http://a.com');
+      const actual = warnUploadOverwrite.__get__('getStoredHash')('someid');
+      expect(actual).to.equal(undefined);
+    });
+
+    it('handles JSON parsing exception', () => {
+      sinon.stub(fs, 'read').returns('{');
+      sinon.stub(environment, 'apiUrl').get(() => 'http://a.com');
+      const actual = warnUploadOverwrite.__get__('getStoredHash')('someid');
+      expect(actual).to.equal(undefined);
+    });
+
+    it('handles missing snapshot id', () => {
+      const given = { id1: { 'a.com/medic': 'abc' } };
+      sinon.stub(fs, 'read').returns(JSON.stringify(given));
+      sinon.stub(environment, 'apiUrl').get(() => 'http://a.com');
+      const actual = warnUploadOverwrite.__get__('getStoredHash')('id2');
+      expect(actual).to.equal(undefined);
+    });
+
+    it('handles missing environment key', () => {
+      const given = { id1: { 'a.com/medic': 'abc' } };
+      sinon.stub(fs, 'read').returns(JSON.stringify(given));
+      sinon.stub(environment, 'apiUrl').get(() => 'http://b.com');
+      const actual = warnUploadOverwrite.__get__('getStoredHash')('id1');
+      expect(actual).to.equal(undefined);
+    });
+
+    it('returns matching snapshot with default db name', () => {
+      const given = { id1: { 'a.com/medic': 'abc' } };
+      sinon.stub(fs, 'read').returns(JSON.stringify(given));
+      sinon.stub(environment, 'apiUrl').get(() => 'http://a.com');
+      const actual = warnUploadOverwrite.__get__('getStoredHash')('id1');
+      expect(actual).to.equal('abc');
+    });
+
+    it('returns matching snapshot with specified db name for remote domain', () => {
+      const given = {
+        id1: {
+          'a.com/medic': 'zzz',
+          'a.com/not-medic': 'abc'
+        },
+        id2: {
+          'a.com/not-medic': 'zzz'
+        }
+      };
+      sinon.stub(fs, 'read').returns(JSON.stringify(given));
+      sinon.stub(environment, 'apiUrl').get(() => 'http://a.com/not-medic');
+      const actual = warnUploadOverwrite.__get__('getStoredHash')('id1');
+      expect(fs.read.callCount).to.equal(1);
+      expect(fs.read.args[0][0]).to.equal('.snapshots/remote.json');
+      expect(actual).to.equal('abc');
+    });
+
+    it('returns matching snapshot with specified db name for localhost', () => {
+      const given = { id1: { 'localhost/medic': 'abc' } };
+      sinon.stub(fs, 'read').returns(JSON.stringify(given));
+      sinon.stub(environment, 'apiUrl').get(() => 'http://admin:pass@localhost:35423/medic');
+      const actual = warnUploadOverwrite.__get__('getStoredHash')('id1');
+      expect(fs.read.callCount).to.equal(1);
+      expect(fs.read.args[0][0]).to.equal('.snapshots/local.json');
+      expect(actual).to.equal('abc');
+    });
+
   });
 
   describe('prompts when attempting to overwrite docs', () => {
@@ -55,7 +141,10 @@ describe('warn-upload-overwrite', () => {
       const localDoc = { _id: 'a' };
       warnUploadOverwrite.postUploadDoc(localDoc);
       assert.equal(write.callCount, 1);
-      assert.equal(write.args[0][1], '{"a":{"y/m":"a-12","localhost/medic":"E/lFVU12AAqbmWbH9LLbtA=="}}');
+      assert.deepEqual(
+        JSON.parse(write.args[0][1]),
+        { a: { 'y/m': 'a-12', 'localhost/medic': 'E/lFVU12AAqbmWbH9LLbtA==' } }
+      );
     });
   });
 
@@ -69,7 +158,7 @@ describe('warn-upload-overwrite', () => {
       sinon.stub(fs, 'read').returns('{"x":{"localhost/medic":"y"}}');
       const localXml = '<?xml version="1.0"?><x />';
       const localDoc = { _id: 'x' };
-      return warnUploadOverwrite.preUploadForm(api.db, localDoc, localXml).then(() => {
+      return warnUploadOverwrite.preUploadForm(api.db, localDoc, localXml, []).then(() => {
         assert.equal(calls.length, 1);
         assert.equal(calls[0][0], '/\n\tExpected element \'x\' instead of \'y\'');
       });
@@ -83,7 +172,7 @@ describe('warn-upload-overwrite', () => {
       sinon.stub(fs, 'read').returns('{"localhost/medic":"y"}');
       const localXml = '<?xml version="1.0"?><x />';
       const localDoc = { _id: 'x' };
-      return warnUploadOverwrite.preUploadForm(api.db, localDoc, localXml).catch(e => {
+      return warnUploadOverwrite.preUploadForm(api.db, localDoc, localXml, []).catch(e => {
         assert.equal('configuration modified', e.message);
       });
     });
@@ -95,7 +184,7 @@ describe('warn-upload-overwrite', () => {
       sinon.stub(fs, 'read').returns('{"localhost/medic":"y"}');
       const localXml = '<?xml version="1.0"?><x />';
       const localDoc = { _id: 'x' };
-      return warnUploadOverwrite.preUploadForm(api.db, localDoc, localXml).then(() => {
+      return warnUploadOverwrite.preUploadForm(api.db, localDoc, localXml, []).then(() => {
         assert(getAttachment.calledOnce);
       });
     });

--- a/test/lib/warn-upload-overwrite.spec.js
+++ b/test/lib/warn-upload-overwrite.spec.js
@@ -6,125 +6,109 @@ const readline = require('readline-sync');
 const warnUploadOverwrite = require('../../src/lib/warn-upload-overwrite');
 const log = require('../../src/lib/log');
 
-describe('prompts when attempting to overwrite (by rev)', () => {
-  beforeEach(api.start);
-  afterEach(api.stop);
+let calls;
 
-  it('throws an error when no local revs exists and the user aborts the overwrite', () => {
-    readline.keyInYN = () => false;
+describe('warn-upload-overwrite', () => {
 
-    return warnUploadOverwrite.preUploadByRev(api.db, {})
-    .catch(e => {
-      assert.equal('configuration modified', e.message);
-    });
-  });
-
-  it('shows diff when local rev is different from remote rev and the user requests a diff', () => {
-    const calls = [];
+  beforeEach(() => {
+    calls = [];
     log.info = (...args) => {
       calls.push(args);
     };
+    sinon.stub(fs, 'exists').returns(true);
+    api.start();
+  });
 
-    readline.keyInYN = () => true;
-    readline.keyInSelect = () => 2;
-    api.db.get = () => {
-      const remoteDoc = { _rev: 'x' };
-      return remoteDoc;
-    };
-    fs.read = () => '{"localhost/medic":"y"}';
-    const localDoc = { _rev: 'y' };
+  afterEach(() => {
+    sinon.restore();
+    api.stop();
+  });
 
-    return warnUploadOverwrite.preUploadByRev(api.db, localDoc)
-    .then(() => {
-      assert.equal(calls.length, 1);
-      assert.equal(calls[0][0], ' {\n\u001b[31m-  _rev: "x"\u001b[39m\n\u001b[32m+  _rev: "y"\u001b[39m\n }\n');
+  describe('prompts when attempting to overwrite (by rev)', () => {
+
+    it('throws an error when no local revs exists and the user aborts the overwrite', () => {
+      sinon.stub(readline, 'keyInYN').returns(false);
+      return warnUploadOverwrite.preUploadByRev(api.db, {}).catch(e => {
+        assert.equal('configuration modified', e.message);
+      });
+    });
+
+    it('shows diff when local rev is different from remote rev and the user requests a diff', () => {
+      sinon.stub(readline, 'keyInYN').returns(true);
+      sinon.stub(readline, 'keyInSelect').returns(2);
+      sinon.stub(api.db, 'get').resolves({ _rev: 'x' });
+      sinon.stub(fs, 'read').returns(JSON.stringify({ a: { 'localhost/medic': 'y' }}));
+      const localDoc = { _id: 'a', _rev: 'y' };
+      return warnUploadOverwrite.preUploadByRev(api.db, localDoc).then(() => {
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0][0], ' {\n\u001b[32m+  _id: "a"\u001b[39m\n\u001b[31m-  _rev: "x"\u001b[39m\n\u001b[32m+  _rev: "y"\u001b[39m\n }\n');
+      });
+    });
+
+    it('aborts when local rev is different from remote rev and the user requests an abort', () => {
+      sinon.stub(readline, 'keyInYN').returns(true);
+      sinon.stub(readline, 'keyInSelect').returns(3);
+      sinon.stub(api.db, 'get').resolves({ _rev: 'x' });
+      sinon.stub(fs, 'read').returns(JSON.stringify({ a: { 'localhost/medic': 'y' }}));
+      const localDoc = { _id: 'a', _rev: 'y' };
+      return warnUploadOverwrite.preUploadByRev(api.db, localDoc).catch(e => {
+        assert.equal('configuration modified', e.message);
+      });
+    });
+
+    it('removes username and password from couchUrl before writing', () => {
+      sinon.stub(api.db, 'get').resolves({ _rev: 'y-23' });
+      const write = sinon.stub(fs, 'write').returns();
+      sinon.stub(fs, 'read').returns(JSON.stringify({ a: { 'y/m': 'a-12' }}));
+      const localDoc = { _id: 'a' };
+      return warnUploadOverwrite.postUploadByRev(api.db, localDoc).then(() => {
+        assert.equal(write.callCount, 1);
+        assert.equal(write.args[0][1], '{"a":{"y/m":"a-12","localhost/medic":"y-23"}}');
+      });
     });
   });
 
-  it('aborts when local rev is different from remote rev and the user requests an abort', () => {
-    readline.keyInYN = () => true;
-    readline.keyInSelect = () => 3;
-    api.db.get = () => {
-      const remoteDoc = { _rev: 'x' };
-      return remoteDoc;
-    };
-    fs.read = () => '{"localhost/medic":"y"}';
-    const localDoc = { _rev: 'y' };
+  describe('prompts when attempting to overwrite (by xml)', () => {
 
-    return warnUploadOverwrite.preUploadByRev(api.db, localDoc)
-    .catch(e => {
-      assert.equal('configuration modified', e.message);
+    it('shows diff when local xml is different from remote xml and the user requests a diff', () => {
+      sinon.stub(readline, 'keyInYN').returns(true);
+      sinon.stub(readline, 'keyInSelect').returns(2);
+      sinon.stub(api.db, 'get').resolves({ _rev: 'x', _attachments: { xml: { digest: 'abc' } } });
+      sinon.stub(api.db, 'getAttachment').resolves(Buffer.from('<?xml version="1.0"?><y />', 'utf8'));
+      sinon.stub(fs, 'read').returns('{"x":{"localhost/medic":"y"}}');
+      const localXml = '<?xml version="1.0"?><x />';
+      const localDoc = { _id: 'x' };
+      return warnUploadOverwrite.preUploadByXml(api.db, localDoc, localXml).then(() => {
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0][0], '/\n\tExpected element \'x\' instead of \'y\'');
+      });
     });
-  });
 
-  it('removes username and passoword from couchUrl before writing', () => {
-    api.db.get = () => {
-      const remoteDoc = { _rev: 'y-23' };
-      return remoteDoc;
-    };
-    const calls = [];
-    fs.write = (...args) => {
-      calls.push(args);
-    };
-    fs.exists = () => true;
-    fs.read = () => '{"y/m":"a-12"}';
-    const localDoc = { _id: 'x' };
-
-    return warnUploadOverwrite.postUploadByRev(api.db, localDoc)
-    .then(() => {
-      assert.equal(calls.length, 1);
-      assert.equal(calls[0][1], '{"y/m":"a-12","localhost/medic":"y-23"}');
+    it('aborts when local xml is different from remote xml and the user requests an abort', () => {
+      sinon.stub(readline, 'keyInYN').returns(true);
+      sinon.stub(readline, 'keyInSelect').returns(3);
+      sinon.stub(api.db, 'get').resolves({ _rev: 'x', _attachments: { xml: { digest: 'abc' } } });
+      sinon.stub(api.db, 'getAttachment').resolves(Buffer.from('<?xml version="1.0"?><y />', 'utf8'));
+      sinon.stub(fs, 'read').returns('{"localhost/medic":"y"}');
+      const localXml = '<?xml version="1.0"?><x />';
+      const localDoc = { _id: 'x' };
+      return warnUploadOverwrite.preUploadByXml(api.db, localDoc, localXml).catch(e => {
+        assert.equal('configuration modified', e.message);
+      });
     });
-  });
-});
 
-describe('prompts when attempting to overwrite (by xml)', () => {
-  beforeEach(api.start);
-  afterEach(api.stop);
-
-  it('shows diff when local xml is different from remote xml and the user requests a diff', () => {
-    const calls = [];
-    log.info = (...args) => {
-      calls.push(args);
-    };
-
-    readline.keyInYN = () => true;
-    readline.keyInSelect = () => 2;
-    api.db.getAttachment = () => Buffer.from('<?xml version="1.0"?><y />', 'utf8');
-    fs.read = () => '{"localhost/medic":"y"}';
-    const localXml = '<?xml version="1.0"?><x />';
-
-    return warnUploadOverwrite.preUploadByXml(api.db, 'x', localXml)
-    .then(() => {
-      assert.equal(calls.length, 1);
-      assert.equal(calls[0][0], '/\n\tExpected element \'x\' instead of \'y\'');
+    it('uploads the local xml if remote xml does not exist', () => {
+      let error = new Error('No attachment');
+      error.status = 404;
+      const getAttachment = sinon.stub(api.db, 'get').rejects(error);
+      sinon.stub(fs, 'read').returns('{"localhost/medic":"y"}');
+      const localXml = '<?xml version="1.0"?><x />';
+      const localDoc = { _id: 'x' };
+      return warnUploadOverwrite.preUploadByXml(api.db, localDoc, localXml).then(() => {
+        assert(getAttachment.calledOnce);
+      });
     });
-  });
 
-  it('aborts when local xml is different from remote xml and the user requests an abort', () => {
-    readline.keyInYN = () => true;
-    readline.keyInSelect = () => 3;
-    api.db.getAttachment = () => Buffer.from('<?xml version="1.0"?><y />', 'utf8');
-    fs.read = () => '{"localhost/medic":"y"}';
-    const localXml = '<?xml version="1.0"?><x />';
-
-    return warnUploadOverwrite.preUploadByXml(api.db, 'x', localXml)
-    .catch(e => {
-      assert.equal('configuration modified', e.message);
-    });
-  });
-
-  it('uploads the local xml if remote xml does not exist', () => {
-    let error = new Error('No attachment');
-    error.status = 404;
-    api.db.getAttachment = sinon.stub().throws(error);
-    fs.read = () => '{"localhost/medic":"y"}';
-    const localXml = '<?xml version="1.0"?><x />';
-
-    return warnUploadOverwrite.preUploadByXml(api.db, 'x', localXml)
-    .then(() => {
-      assert(api.db.getAttachment.calledOnce);
-    });
   });
 
 });


### PR DESCRIPTION
Otherwise we skip over the form assuming that nothing has changed.

Additionally check local content against remote content before
checking stored hash to better detect when local is out of sync
with remote.

Also changes the hashes directory structure to support Windows. This
is not backwards compatible so users will be prompted to overwrite
the next time they upload config.

Additionally this change also makes it possible to configure the `xml2sms`
property on xforms.

#271
#300
#301
#303
#306