### PR TITLE
Add .gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 express-pouchdb.log
 upload-docs.*.log.json
 /.vscode/
+/.idea/
+/.settings/
+*.swp


### PR DESCRIPTION
Add .gitignore rules to omit IntelliJ* (IDEA, WebStorm...), Eclipse and Vi* configurations and temp files.