### PR TITLE
269 - Log warning for deprecated transitions

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -5,16 +5,16 @@ const environment = require('./environment');
 const log = require('../lib/log');
 
 const logDeprecatedTransitions = (settings) => {
+  const appSettings = JSON.parse(settings);
+
+  if (!appSettings.transitions || !Object.keys(appSettings.transitions).length) {
+    return;
+  }
+
   const uri = `${environment.instanceUrl}/api/v1/settings/deprecated-transitions`;
 
   return request({ uri, method: 'GET', json: true})
     .then(transitions => {
-      const appSettings = JSON.parse(settings);
-
-      if (!appSettings.transitions) {
-        return;
-      }
-
       (transitions || []).forEach(transition => {
         const transitionSetting = appSettings.transitions[transition.name];
         const disabled = transitionSetting && transitionSetting.disable;

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -2,6 +2,35 @@ const request = require('request-promise-native');
 
 const archivingApi = require('./archiving-api');
 const environment = require('./environment');
+const log = require('../lib/log');
+
+const logDeprecatedTransitions = (settings) => {
+  const uri = `${environment.instanceUrl}/api/v1/settings/deprecated-transitions`;
+
+  return request({ uri, method: 'GET', json: true})
+    .then(transitions => {
+      const appSettings = JSON.parse(settings);
+
+      if (appSettings.transitions) {
+        (transitions || []).forEach(transition => {
+          const transitionSetting = appSettings.transitions[transition.name];
+
+          if (transitionSetting === true || (transitionSetting && transitionSetting.disable === false)) {
+            log.warn(transition.deprecationMessage);
+          }
+        });
+      }
+    });
+};
+
+const updateAppSettings = (settings) => {
+  return request.put({
+    method: 'PUT',
+    url: `${environment.apiUrl}/_design/medic/_rewrite/update_settings/medic?replace=1`,
+    headers: {'Content-Type': 'application/json'},
+    body: settings,
+  });
+};
 
 const api = {
   getAppSettings: () => {
@@ -17,12 +46,21 @@ const api = {
       });
   },
 
-  updateAppSettings: (content) => request.put({
-      method: 'PUT',
-      url: `${environment.apiUrl}/_design/medic/_rewrite/update_settings/medic?replace=1`,
-      headers: { 'Content-Type':'application/json' },
-      body: content,
-    }),
+  updateAppSettings: (content) => {
+    return Promise.allSettled([
+      updateAppSettings(content),
+      logDeprecatedTransitions(content)
+    ]).then(([updateSettingsResp, logTransitionResp]) => {
+      if (logTransitionResp.status === 'rejected') {
+        // Log error and continue with the work, this isn't a blocking task.
+        log.error('Error in logging deprecated transitions:', logTransitionResp.reason);
+      }
+      if (updateSettingsResp.status === 'rejected') {
+        throw updateSettingsResp.reason;
+      }
+      return updateSettingsResp.value;
+    });
+  },
 
   createUser(userData) {
     return request({

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -11,14 +11,22 @@ const logDeprecatedTransitions = (settings) => {
     .then(transitions => {
       const appSettings = JSON.parse(settings);
 
-      if (appSettings.transitions) {
-        (transitions || []).forEach(transition => {
-          const transitionSetting = appSettings.transitions[transition.name];
+      if (!appSettings.transitions) {
+        return;
+      }
 
-          if (transitionSetting === true || (transitionSetting && transitionSetting.disable === false)) {
-            log.warn(transition.deprecationMessage);
-          }
-        });
+      (transitions || []).forEach(transition => {
+        const transitionSetting = appSettings.transitions[transition.name];
+        const disabled = transitionSetting && transitionSetting.disable;
+
+        if (transitionSetting && !disabled) {
+          log.warn(transition.deprecationMessage);
+        }
+      });
+    })
+    .catch(error => {
+      if (error.statusCode !== 404) {
+        throw error;
       }
     });
 };


### PR DESCRIPTION
# Description

Adding a call to the Deprecated Transition GET endpoint and log a warning if any of the new settings is enabling a deprecated transition.  

https://github.com/medic/medic-conf/issues/269

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.