### PR TITLE
64 - New git-check action

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For configuring against Medic Mobile-hosted instances.
 
 	medic-conf --instance=instance-name.dev
 
-Username `admin` is used.  A prompt is shown for entering password.
+Username `admin` is used. A prompt is shown for entering password.
 
 If a different username is required, add the `--user` switch:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5933,8 +5933,7 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "open": "^7.0.2",
+    "pluralize": "^7.0.0",
     "pouchdb-adapter-http": "^7.1.1",
     "pouchdb-core": "^7.1.1",
     "pouchdb-mapreduce": "^7.1.1",

--- a/src/bin/shell-completion.js
+++ b/src/bin/shell-completion.js
@@ -6,7 +6,7 @@ const options = [
     '--instance', '--local', '--url', '--user',
     '--help', '--shell-completion', '--supported-actions',
     '--version', '--accept-self-signed-certs', '--skip-dependency-check',
-    '--skip-translation-check', '--force',
+    '--skip-git-check', '--skip-translation-check', '--force',
     ...require('../cli/supported-actions'),
 ];
 

--- a/src/cli/usage.js
+++ b/src/cli/usage.js
@@ -57,6 +57,9 @@ ${bold('OPTIONS')}
   --skip-dependency-check
     Skips checking the version running is set to the same version in the package.json
 
+  --skip-git-check
+    Skips checking the status of the current repository that holds the configuration
+
   --skip-translation-check
     Skips checking message translations
 

--- a/src/fn/check-git.js
+++ b/src/fn/check-git.js
@@ -9,7 +9,8 @@ module.exports = {
     if (status) {
       warn('There are changes in your local branch to be committed or ' +
            'not staged for commit.');
-      if(!readline.keyInYN('Are you sure you want to push config?')) {
+      warn('Changes untracked or to be committed:\n' + status);
+      if(!readline.keyInYN('Are you sure you want to continue?')) {
         error('User failed to confirm action.');
         process.exit(-1);
       }
@@ -18,7 +19,7 @@ module.exports = {
     const syncStatus = await git.checkUpstream();
     if (syncStatus) {
       warn(syncStatus);
-      if(!readline.keyInYN('Are you sure you want to push config?')) {
+      if(!readline.keyInYN('Are you sure you want to continue?')) {
         error('User failed to confirm action.');
         process.exit(-1);
       }

--- a/src/fn/check-git.js
+++ b/src/fn/check-git.js
@@ -15,7 +15,6 @@ module.exports = {
         process.exit(-1);
       }
     }
-    await git.fetch();
     const syncStatus = await git.checkUpstream();
     if (syncStatus) {
       warn(syncStatus);

--- a/src/fn/check-git.js
+++ b/src/fn/check-git.js
@@ -1,6 +1,6 @@
 const git = require('../lib/git-exec');
-const { warn, error } = require('../lib/log');
-const readline = require('readline-sync');
+const { info, warn, error } = require('../lib/log');
+const userPrompt = require('../lib/user-prompt');
 
 module.exports = {
   requiresInstance: false,
@@ -11,15 +11,16 @@ module.exports = {
         warn('There are changes in your local branch to be committed or ' +
           'not staged for commit.');
         warn('Changes untracked or to be committed:\n' + status);
-        if (!readline.keyInYN('Are you sure you want to continue?')) {
+        if (!userPrompt.keyInYN('Are you sure you want to continue?')) {
           error('User failed to confirm action.');
           process.exit(-1);
         }
       }
+      info('Fetching git upstream...');
       const syncStatus = await git.checkUpstream();
       if (syncStatus) {
         warn(syncStatus);
-        if (!readline.keyInYN('Are you sure you want to continue?')) {
+        if (!userPrompt.keyInYN('Are you sure you want to continue?')) {
           error('User failed to confirm action.');
           process.exit(-1);
         }

--- a/src/fn/check-git.js
+++ b/src/fn/check-git.js
@@ -6,21 +6,23 @@ module.exports = {
   requiresInstance: false,
   execute: async () => {
     const status = await git.status();
-    if (status) {
-      warn('There are changes in your local branch to be committed or ' +
-           'not staged for commit.');
-      warn('Changes untracked or to be committed:\n' + status);
-      if(!readline.keyInYN('Are you sure you want to continue?')) {
-        error('User failed to confirm action.');
-        process.exit(-1);
+    if (status !== null) {
+      if (status !== '') {
+        warn('There are changes in your local branch to be committed or ' +
+          'not staged for commit.');
+        warn('Changes untracked or to be committed:\n' + status);
+        if (!readline.keyInYN('Are you sure you want to continue?')) {
+          error('User failed to confirm action.');
+          process.exit(-1);
+        }
       }
-    }
-    const syncStatus = await git.checkUpstream();
-    if (syncStatus) {
-      warn(syncStatus);
-      if(!readline.keyInYN('Are you sure you want to continue?')) {
-        error('User failed to confirm action.');
-        process.exit(-1);
+      const syncStatus = await git.checkUpstream();
+      if (syncStatus) {
+        warn(syncStatus);
+        if (!readline.keyInYN('Are you sure you want to continue?')) {
+          error('User failed to confirm action.');
+          process.exit(-1);
+        }
       }
     }
   }

--- a/src/fn/check-git.js
+++ b/src/fn/check-git.js
@@ -1,0 +1,27 @@
+const git = require('../lib/git-exec');
+const { warn, error } = require('../lib/log');
+const readline = require('readline-sync');
+
+module.exports = {
+  requiresInstance: false,
+  execute: async () => {
+    const status = await git.status();
+    if (status) {
+      warn('There are changes in your local branch to be committed or ' +
+           'not staged for commit.');
+      if(!readline.keyInYN('Are you sure you want to push config?')) {
+        error('User failed to confirm action.');
+        process.exit(-1);
+      }
+    }
+    await git.fetch();
+    const syncStatus = await git.checkUpstream();
+    if (syncStatus) {
+      warn(syncStatus);
+      if(!readline.keyInYN('Are you sure you want to push config?')) {
+        error('User failed to confirm action.');
+        process.exit(-1);
+      }
+    }
+  }
+};

--- a/src/fn/check-git.js
+++ b/src/fn/check-git.js
@@ -1,10 +1,15 @@
 const git = require('../lib/git-exec');
 const { info, warn, error } = require('../lib/log');
 const userPrompt = require('../lib/user-prompt');
+const environment = require('../lib/environment');
 
 module.exports = {
   requiresInstance: false,
   execute: async () => {
+    if (!environment.isProduction() && environment.instanceUrl) {
+      // is not production and there is an instance URL set
+      return info('No production environment detected: skipping check-git…');
+    }
     const status = await git.status();
     if (status !== null) {
       if (status !== '') {

--- a/src/fn/compress-pngs.js
+++ b/src/fn/compress-pngs.js
@@ -1,7 +1,7 @@
 const environment = require('../lib/environment');
 const exec = require('../lib/exec-promise');
 const fs = require('../lib/sync-fs');
-const { info, trace, level } = require('../lib/log');
+const { info, trace } = require('../lib/log');
 
 module.exports = {
   requiresInstance: false,
@@ -12,7 +12,7 @@ module.exports = {
         promiseChain
           .then(() => info('Compressing PNG:', png, '…'))
           .then(() =>
-              exec(level,'pngout-medic', `'${png}'`)
+              exec(['pngout-medic', `'${png}'`])
                 .then(() => trace('Compressed', png))
                 .catch(e => {
                   if(e.status === 2) {

--- a/src/fn/compress-pngs.js
+++ b/src/fn/compress-pngs.js
@@ -1,7 +1,7 @@
 const environment = require('../lib/environment');
 const exec = require('../lib/exec-promise');
 const fs = require('../lib/sync-fs');
-const { info, trace } = require('../lib/log');
+const { info, trace, level } = require('../lib/log');
 
 module.exports = {
   requiresInstance: false,
@@ -12,7 +12,7 @@ module.exports = {
         promiseChain
           .then(() => info('Compressing PNG:', png, '…'))
           .then(() =>
-              exec('pngout-medic', `'${png}'`)
+              exec(level,'pngout-medic', `'${png}'`)
                 .then(() => trace('Compressed', png))
                 .catch(e => {
                   if(e.status === 2) {

--- a/src/lib/convert-forms.js
+++ b/src/lib/convert-forms.js
@@ -3,7 +3,7 @@ const { execSync } = require('child_process');
 const argsFormFilter = require('./args-form-filter');
 const exec = require('./exec-promise');
 const fs = require('./sync-fs');
-const { info, trace, warn } = require('./log');
+const { info, trace, warn, level } = require('./log');
 
 const XLS2XFORM = 'xls2xform-medic';
 const INSTALLATION_INSTRUCTIONS = `\nE To install the latest pyxform, try one of the following:
@@ -54,7 +54,7 @@ module.exports = async (projectDir, subDirectory, options) => {
 };
 
 const xls2xform = (sourcePath, targetPath) =>
-    exec(XLS2XFORM, '--skip_validate', sourcePath, targetPath)
+    exec(level, XLS2XFORM, '--skip_validate', sourcePath, targetPath)
       .catch(e => {
         if(executableAvailable()) {
           if(e.includes('unrecognized arguments: --skip_validate')) {

--- a/src/lib/convert-forms.js
+++ b/src/lib/convert-forms.js
@@ -3,7 +3,7 @@ const { execSync } = require('child_process');
 const argsFormFilter = require('./args-form-filter');
 const exec = require('./exec-promise');
 const fs = require('./sync-fs');
-const { info, trace, warn, level } = require('./log');
+const { info, trace, warn } = require('./log');
 
 const XLS2XFORM = 'xls2xform-medic';
 const INSTALLATION_INSTRUCTIONS = `\nE To install the latest pyxform, try one of the following:
@@ -54,7 +54,7 @@ module.exports = async (projectDir, subDirectory, options) => {
 };
 
 const xls2xform = (sourcePath, targetPath) =>
-    exec(level, XLS2XFORM, '--skip_validate', sourcePath, targetPath)
+    exec([XLS2XFORM, '--skip_validate', sourcePath, targetPath])
       .catch(e => {
         if(executableAvailable()) {
           if(e.includes('unrecognized arguments: --skip_validate')) {

--- a/src/lib/environment.js
+++ b/src/lib/environment.js
@@ -1,3 +1,8 @@
+const url = require('url');
+
+const LOCAL_MATCHER = /^(.*localhost|::1|127\.0\.0\.\d{1,3})$/;
+const DEV_MATCHER = /^(dev|test|staging)(-\w+|\d+)?$/;  // dev, test1, test-xx, ...
+
 const state = {};
 
 const initialize = (
@@ -35,5 +40,16 @@ module.exports = {
   get extraArgs() { return state.extraArgs; },
   get apiUrl() { return state.apiUrl; },
   get force() { return state.force; },
-  get skipTranslationCheck() { return state.skipTranslationCheck; }
+  get skipTranslationCheck() { return state.skipTranslationCheck; },
+
+  /**
+   * Return `true` if the environment seems to be production.
+   * @returns {boolean}
+   */
+  isProduction() {
+    if (!this.instanceUrl) return false;
+    const hostname = url.parse(this.instanceUrl).hostname;
+    if (LOCAL_MATCHER.test(hostname)) return false;
+    return !hostname.split('.').some(subdomain => DEV_MATCHER.test(subdomain));
+  }
 };

--- a/src/lib/environment.js
+++ b/src/lib/environment.js
@@ -43,13 +43,17 @@ module.exports = {
   get skipTranslationCheck() { return state.skipTranslationCheck; },
 
   /**
-   * Return `true` if the environment seems to be production.
+   * Return `true` if the environment **seems** to be production.
    * @returns {boolean}
    */
   isProduction() {
-    if (!this.instanceUrl) return false;
+    if (!this.instanceUrl) {
+      return false;
+    }
     const hostname = url.parse(this.instanceUrl).hostname;
-    if (LOCAL_MATCHER.test(hostname)) return false;
+    if (LOCAL_MATCHER.test(hostname)) {
+      return false;
+    }
     return !hostname.split('.').some(subdomain => DEV_MATCHER.test(subdomain));
   }
 };

--- a/src/lib/exec-promise.js
+++ b/src/lib/exec-promise.js
@@ -17,7 +17,7 @@ module.exports = (...args) => new Promise((resolve, reject) => {
       { stdio:stdio },
       (err, stdout, stderr) => {
         if(err) reject(stderr);
-        else resolve();
+        else resolve(stdout);
       });
 
     if(log.level >= log.LEVEL_WARN)  sub.stdout.pipe(process.stdout);

--- a/src/lib/exec-promise.js
+++ b/src/lib/exec-promise.js
@@ -4,13 +4,13 @@ const log = require('../lib/log');
 // TODO might be important to sanitise input to `exec()` to prevent injection
 // attacks by devious tech leads.
 
-module.exports = (log_level, ...args) => new Promise((resolve, reject) => {
+module.exports = (args, logLevel=log.level) => new Promise((resolve, reject) => {
 
     // Include stdout at log.LEVEL_WARN because xls2xform outputs warnings on stdout
 
-    const stdio = log_level >= log.LEVEL_WARN  ? [ 'ignore',  'pipe',   'pipe'  ] :
-                  log_level >= log.LEVEL_ERROR ? [ 'ignore', 'ignore',  'pipe'  ] :
-                                                 [ 'ignore', 'ignore', 'ignore' ];
+    const stdio = logLevel >= log.LEVEL_WARN  ? [ 'ignore',  'pipe',   'pipe'  ] :
+                  logLevel >= log.LEVEL_ERROR ? [ 'ignore', 'ignore',  'pipe'  ] :
+                                                [ 'ignore', 'ignore', 'ignore' ];
 
     const sub = exec(
       args.join(' '),
@@ -20,7 +20,7 @@ module.exports = (log_level, ...args) => new Promise((resolve, reject) => {
         else resolve(stdout);
       });
 
-    if(log_level >= log.LEVEL_WARN)  sub.stdout.pipe(process.stdout);
-    if(log_level >= log.LEVEL_ERROR) sub.stderr.pipe(process.stderr);
+    if(logLevel >= log.LEVEL_WARN)  sub.stdout.pipe(process.stdout);
+    if(logLevel >= log.LEVEL_ERROR) sub.stderr.pipe(process.stderr);
 
   });

--- a/src/lib/exec-promise.js
+++ b/src/lib/exec-promise.js
@@ -4,12 +4,12 @@ const log = require('../lib/log');
 // TODO might be important to sanitise input to `exec()` to prevent injection
 // attacks by devious tech leads.
 
-module.exports = (...args) => new Promise((resolve, reject) => {
+module.exports = (log_level, ...args) => new Promise((resolve, reject) => {
 
     // Include stdout at log.LEVEL_WARN because xls2xform outputs warnings on stdout
 
-    const stdio = log.level >= log.LEVEL_WARN  ? [ 'ignore',  'pipe',   'pipe'  ] :
-                  log.level >= log.LEVEL_ERROR ? [ 'ignore', 'ignore',  'pipe'  ] :
+    const stdio = log_level >= log.LEVEL_WARN  ? [ 'ignore',  'pipe',   'pipe'  ] :
+                  log_level >= log.LEVEL_ERROR ? [ 'ignore', 'ignore',  'pipe'  ] :
                                                  [ 'ignore', 'ignore', 'ignore' ];
 
     const sub = exec(
@@ -20,7 +20,7 @@ module.exports = (...args) => new Promise((resolve, reject) => {
         else resolve(stdout);
       });
 
-    if(log.level >= log.LEVEL_WARN)  sub.stdout.pipe(process.stdout);
-    if(log.level >= log.LEVEL_ERROR) sub.stderr.pipe(process.stderr);
+    if(log_level >= log.LEVEL_WARN)  sub.stdout.pipe(process.stdout);
+    if(log_level >= log.LEVEL_ERROR) sub.stderr.pipe(process.stderr);
 
   });

--- a/src/lib/exec-promise.js
+++ b/src/lib/exec-promise.js
@@ -8,9 +8,14 @@ module.exports = (args, logLevel=log.level) => new Promise((resolve, reject) => 
 
     // Include stdout at log.LEVEL_WARN because xls2xform outputs warnings on stdout
 
-    const stdio = logLevel >= log.LEVEL_WARN  ? [ 'ignore',  'pipe',   'pipe'  ] :
-                  logLevel >= log.LEVEL_ERROR ? [ 'ignore', 'ignore',  'pipe'  ] :
-                                                [ 'ignore', 'ignore', 'ignore' ];
+    let stdio;
+    if (logLevel >= log.LEVEL_WARN) {
+      stdio = [ 'ignore',  'pipe',   'pipe' ];
+    } else if (logLevel >= log.LEVEL_ERROR) {
+      stdio = [ 'ignore', 'ignore',  'pipe' ];
+    } else {
+      stdio = [ 'ignore', 'ignore', 'ignore' ];
+    }
 
     const sub = exec(
       args.join(' '),

--- a/src/lib/git-exec.js
+++ b/src/lib/git-exec.js
@@ -9,7 +9,7 @@ const GIT = 'git';    // Git command path
  * or empty if the working tree is clean.
  */
 module.exports.status = async () => {
-  return (await exec(log.LEVEL_ERROR, GIT, 'status', '--porcelain')).trim();
+  return (await exec([GIT, 'status', '--porcelain'], log.LEVEL_ERROR)).trim();
 };
 
 /**
@@ -17,7 +17,7 @@ module.exports.status = async () => {
  * the upstream repository (but without auto-merge).
  */
 module.exports.fetch = () => {
-  return exec(log.LEVEL_ERROR, GIT, 'fetch');
+  return exec([GIT, 'fetch'], log.LEVEL_ERROR);
 };
 
 /**
@@ -26,7 +26,7 @@ module.exports.fetch = () => {
  * or returns an empty string if is in sync.
  */
 module.exports.checkUpstream = async () => {
-  const result = await exec(log.LEVEL_ERROR, GIT, 'rev-list --left-right --count ...origin');
+  const result = await exec([GIT, 'rev-list --left-right --count ...origin'], log.LEVEL_ERROR);
   const [ahead, behind] = result.split('\t').filter(s=>s).map(Number);
   if (ahead && behind) {
     return `branch is behind upstream by ${pluralize('commit', behind, true)} `

--- a/src/lib/git-exec.js
+++ b/src/lib/git-exec.js
@@ -15,7 +15,7 @@ const NOT_FOUND_REGEX = new RegExp(`[(Cc)ommand|${GIT}].* not found`);
  */
 module.exports.status = async () => {
   try {
-    return await exec([GIT, 'status', '--porcelain'], log.LEVEL_NONE);
+    return await exec([GIT, 'status', '--porcelain', '.'], log.LEVEL_NONE);
   } catch (e) {
     if (typeof e === 'string') {
       if (NOT_FOUND_REGEX.test(e)) {
@@ -67,7 +67,7 @@ module.exports.getUpstream = async () => {
   try {
     return (await exec([GIT, 'rev-parse --abbrev-ref --symbolic-full-name @{u}'], log.LEVEL_NONE)).trim();
   } catch (err) {
-    if (err.message && err.message.indexOf('no upstream configured') >= 0) {
+    if (typeof err === 'string' && err.indexOf('no upstream configured') >= 0) {
       return null;
     }
     throw err;

--- a/src/lib/git-exec.js
+++ b/src/lib/git-exec.js
@@ -1,0 +1,7 @@
+const exec = require('./exec-promise');
+
+const GIT = 'git';    // Git command path
+
+module.exports.gitStatus = () => {
+  return exec(GIT, 'status');
+};

--- a/src/lib/git-exec.js
+++ b/src/lib/git-exec.js
@@ -8,24 +8,17 @@ const GIT = 'git';    // Git command path
  * Returns the working tree status in a string (files to commit),
  * or empty if the working tree is clean.
  */
-module.exports.status = async () => {
-  return (await exec([GIT, 'status', '--porcelain'], log.LEVEL_ERROR)).trim();
+module.exports.status = () => {
+  return exec([GIT, 'status', '--porcelain'], log.LEVEL_ERROR);
 };
 
 /**
- * Sets up to date the local git repository fetching from
- * the upstream repository (but without auto-merge).
- */
-module.exports.fetch = () => {
-  return exec([GIT, 'fetch'], log.LEVEL_ERROR);
-};
-
-/**
- * Compares the current branch against the upstream and returns
- * a message with the result whether it is behind, ahead or both,
- * or returns an empty string if is in sync.
+ * Fetches the upstream repository and compares the current
+ * branch against it, returning a message with the result whether it
+ * is behind, ahead or both. Returns an empty string if it s in sync.
  */
 module.exports.checkUpstream = async () => {
+  await exec([GIT, 'fetch'], log.LEVEL_ERROR);
   const result = await exec([GIT, 'rev-list --left-right --count ...origin'], log.LEVEL_ERROR);
   const [ahead, behind] = result.split('\t').filter(s=>s).map(Number);
   if (ahead && behind) {

--- a/src/lib/git-exec.js
+++ b/src/lib/git-exec.js
@@ -12,6 +12,11 @@ const NOT_FOUND_REGEX = new RegExp(`[(Cc)ommand|${GIT}].* not found`);
  * If there is no git installation or git repository in the
  * working directory it warns a message with the issue and
  * returns `null`.
+ *
+ * NOTE: only changes that affect files in the folder where
+ * the command is executed are taken into account, to avoid
+ * highlighting changes from other configuration folders
+ * in multi-projects repos.
  */
 module.exports.status = async () => {
   try {
@@ -79,11 +84,16 @@ module.exports.getUpstream = async () => {
  * branch against it, returning a message with the result whether it
  * is behind, ahead or both.
  *
- * Returns an empty string if it's in sync.
+ * Returns an empty string if it is in sync.
  *
  * If there is no upstream repository in the
  * working directory it warns a message with the issue and
  * returns `null`.
+ *
+ * NOTE: only commits that affect files in the folder where
+ * the command is executed are taken into account, to avoid
+ * highlighting changes from other configuration folders
+ * in multi-projects repos.
  */
 module.exports.checkUpstream = async () => {
   await exec([GIT, 'fetch'], log.LEVEL_ERROR);
@@ -99,7 +109,7 @@ module.exports.checkUpstream = async () => {
     // Get the commits count from each side that aren't in the other side,
     // eg. `1    3` means 1 commit is ahead in the local repo (not in upstream)
     // while 3 commits from upstream aren't in sync yet in local
-    const result = await exec([GIT, `rev-list --left-right --count ...${upstream}`], log.LEVEL_ERROR);
+    const result = await exec([GIT, `rev-list --left-right --count ...${upstream} .`], log.LEVEL_ERROR);
     const [ahead, behind] = result.split('\t').filter(s => s).map(Number);
     if (ahead && behind) {
       return `branch is behind upstream by ${pluralize('commit', behind, true)} `

--- a/src/lib/git-exec.js
+++ b/src/lib/git-exec.js
@@ -1,5 +1,6 @@
 const exec = require('./exec-promise');
 const pluralize = require('pluralize');
+const log = require('./log');
 
 const GIT = 'git';    // Git command path
 
@@ -7,8 +8,8 @@ const GIT = 'git';    // Git command path
  * Returns the working tree status in a string (files to commit),
  * or empty if the working tree is clean.
  */
-module.exports.status = () => {
-  return exec(GIT, 'status', '--porcelain');
+module.exports.status = async () => {
+  return (await exec(log.LEVEL_ERROR, GIT, 'status', '--porcelain')).trim();
 };
 
 /**
@@ -16,7 +17,7 @@ module.exports.status = () => {
  * the upstream repository (but without auto-merge).
  */
 module.exports.fetch = () => {
-  return exec(GIT, 'fetch');
+  return exec(log.LEVEL_ERROR, GIT, 'fetch');
 };
 
 /**
@@ -25,7 +26,7 @@ module.exports.fetch = () => {
  * or returns an empty string if is in sync.
  */
 module.exports.checkUpstream = async () => {
-  const result = await exec(GIT, 'rev-list --left-right --count ...origin');
+  const result = await exec(log.LEVEL_ERROR, GIT, 'rev-list --left-right --count ...origin');
   const [ahead, behind] = result.split('\t').filter(s=>s).map(Number);
   if (ahead && behind) {
     return `branch is behind upstream by ${pluralize('commit', behind, true)} `

--- a/src/lib/git-exec.js
+++ b/src/lib/git-exec.js
@@ -3,33 +3,101 @@ const pluralize = require('pluralize');
 const log = require('./log');
 
 const GIT = 'git';    // Git command path
+const NOT_FOUND_REGEX = new RegExp(`[(Cc)ommand|${GIT}].* not found`);
 
 /**
  * Returns the working tree status in a string (files to commit),
  * or empty if the working tree is clean.
+ *
+ * If there is no git installation or git repository in the
+ * working directory it warns a message with the issue and
+ * returns `null`.
  */
-module.exports.status = () => {
-  return exec([GIT, 'status', '--porcelain'], log.LEVEL_ERROR);
+module.exports.status = async () => {
+  try {
+    return await exec([GIT, 'status', '--porcelain'], log.LEVEL_NONE);
+  } catch (e) {
+    if (typeof e === 'string') {
+      if (NOT_FOUND_REGEX.test(e)) {
+        log.warn(`Command ${GIT} not found`);
+        return null;
+      }
+      if (e.indexOf('not a git repository') >= 0) {
+        log.warn('git repository not found');
+        return null;
+      }
+      throw new Error(e);
+    }
+    throw e;
+  }
+};
+
+/**
+ * Returns a string with the upstream repository name
+ * configured in the git repository in the working directory,
+ * normally 'origin'.
+ *
+ * If there is more than one upstream, it returns 'origin' if
+ * it is among the list, or the first found.
+ *
+ * Returns `null` if there are no upstreams repos configured.
+ */
+module.exports.getUpstream = async () => {
+  const result = (await exec([GIT, 'remote'], log.LEVEL_NONE)).trim();
+  if (result) {
+    const lines = result.split('\n');
+    if (lines.length > 1) {
+      const upstream = lines.find(r=> r === 'origin');
+      if (upstream) {
+        return upstream;
+      }
+      return lines[0];
+    }
+    return result;
+  }
+  return null;
 };
 
 /**
  * Fetches the upstream repository and compares the current
  * branch against it, returning a message with the result whether it
- * is behind, ahead or both. Returns an empty string if it s in sync.
+ * is behind, ahead or both.
+ *
+ * Returns an empty string if it's in sync.
+ *
+ * If there is no upstream repository in the
+ * working directory it warns a message with the issue and
+ * returns `null`.
  */
 module.exports.checkUpstream = async () => {
   await exec([GIT, 'fetch'], log.LEVEL_ERROR);
-  const result = await exec([GIT, 'rev-list --left-right --count ...origin'], log.LEVEL_ERROR);
-  const [ahead, behind] = result.split('\t').filter(s=>s).map(Number);
-  if (ahead && behind) {
-    return `branch is behind upstream by ${pluralize('commit', behind, true)} `
-         + `and ahead by ${pluralize('commit', ahead, true)}`;
+  const upstream = await module.exports.getUpstream();
+  if (upstream === null) {
+    log.warn('git upstream repository not found');
+    return null;
   }
-  if (behind) {
-    return `branch is behind upstream by ${pluralize('commit', behind, true)}`;
+  try {
+    const result = await exec([GIT, `rev-list --left-right --count ...${upstream}`], log.LEVEL_ERROR);
+    const [ahead, behind] = result.split('\t').filter(s => s).map(Number);
+    if (ahead && behind) {
+      return `branch is behind upstream by ${pluralize('commit', behind, true)} `
+        + `and ahead by ${pluralize('commit', ahead, true)}`;
+    }
+    if (behind) {
+      return `branch is behind upstream by ${pluralize('commit', behind, true)}`;
+    }
+    if (ahead) {
+      return `branch is ahead upstream by ${pluralize('commit', ahead, true)}`;
+    }
+    return '';
+  } catch (e) {
+    if (typeof e === 'string') {
+      if (e.indexOf('unknown revision or path') >= 0) {
+        log.warn('git repository not found');
+        return false;
+      }
+      throw new Error(e);
+    }
+    throw e;
   }
-  if (ahead) {
-    return `branch is ahead upstream by ${pluralize('commit', ahead, true)}`;
-  }
-  return '';
 };

--- a/src/lib/git-exec.js
+++ b/src/lib/git-exec.js
@@ -26,7 +26,8 @@ module.exports.status = async () => {
         log.warn('git repository not found');
         return null;
       }
-      throw new Error(e);
+      log.warn('git command could not be executed successfully -', e);
+      return null;
     }
     throw e;
   }

--- a/src/lib/git-exec.js
+++ b/src/lib/git-exec.js
@@ -1,7 +1,41 @@
 const exec = require('./exec-promise');
+const pluralize = require('pluralize');
 
 const GIT = 'git';    // Git command path
 
-module.exports.gitStatus = () => {
-  return exec(GIT, 'status');
+/**
+ * Returns the working tree status in a string (files to commit),
+ * or empty if the working tree is clean.
+ */
+module.exports.status = () => {
+  return exec(GIT, 'status', '--porcelain');
+};
+
+/**
+ * Sets up to date the local git repository fetching from
+ * the upstream repository (but without auto-merge).
+ */
+module.exports.fetch = () => {
+  return exec(GIT, 'fetch');
+};
+
+/**
+ * Compares the current branch against the upstream and returns
+ * a message with the result whether it is behind, ahead or both,
+ * or returns an empty string if is in sync.
+ */
+module.exports.checkUpstream = async () => {
+  const result = await exec(GIT, 'rev-list --left-right --count ...origin');
+  const [ahead, behind] = result.split('\t').filter(s=>s).map(Number);
+  if (ahead && behind) {
+    return `branch is behind upstream by ${pluralize('commit', behind, true)} `
+         + `and ahead by ${pluralize('commit', ahead, true)}`;
+  }
+  if (behind) {
+    return `branch is behind upstream by ${pluralize('commit', behind, true)}`;
+  }
+  if (ahead) {
+    return `branch is ahead upstream by ${pluralize('commit', ahead, true)}`;
+  }
+  return '';
 };

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -13,6 +13,7 @@ const usage = require('../cli/usage');
 
 const { error, info, warn } = log;
 const defaultActions = [
+  'check-git',
   'compile-app-settings',
   'backup-app-settings',
   'upload-app-settings',

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -128,6 +128,10 @@ module.exports = async (argv, env) => {
     return -1;
   }
 
+  if (cmdArgs['skip-git-check']) {
+    actions = actions.filter(a => a !== 'check-git');
+  }
+
   actions = actions.map(actionName => {
     const action = require(`../fn/${actionName}`);
 

--- a/src/lib/user-prompt.js
+++ b/src/lib/user-prompt.js
@@ -2,12 +2,24 @@ const environment = require('./environment');
 const readline = require('readline-sync');
 
 
-function keyInYN() {
+/**
+ * Display a query to the user if it's specified, and then return a
+ * boolean or an empty string immediately a key was pressed by the user,
+ * without pressing the Enter key.
+ * If `medic-conf` was called with the `--force` argument, `true`
+ * is immediately returned without displaying any message and without
+ * waiting the user confirmation.
+ * @param {string=} query - the message, by default 'Are you sure? '
+ *        is used
+ * @param {Object=} options - options to pass `readlineSync.keyInYN`
+ *        (see https://www.npmjs.com/package/readline-sync#basic-options)
+ * @returns {boolean|string}
+ */
+function keyInYN(query, options) {
   if (environment.force) {
     return true;
   }
-
-  return readline.keyInYN(); 
+  return readline.keyInYN(query, options);
 }
 
 function question(question, options = {}) {

--- a/test/lib/environment.spec.js
+++ b/test/lib/environment.spec.js
@@ -59,7 +59,7 @@ describe('environment', () => {
     });
 
     it('dev-SOME.* environment return true', () => {
-      sinon.stub(environment, 'instanceUrl').get(() => 'https://some-demo.dev.medicmobile.org');
+      sinon.stub(environment, 'instanceUrl').get(() => 'https://demo.dev-v1.medicmobile.org');
       expect(environment.isProduction()).to.be.false;
     });
   });

--- a/test/lib/environment.spec.js
+++ b/test/lib/environment.spec.js
@@ -1,0 +1,66 @@
+const { expect } = require('chai');
+const environment = require('../../src/lib/environment');
+const sinon = require('sinon');
+
+describe('environment', () => {
+
+  afterEach(sinon.restore);
+
+  describe('isProduction',  () => {
+
+    it('localhost and port environment return false', () => {
+      sinon.stub(environment, 'instanceUrl').get(() => 'http://admin:pass@localhost:5988');
+      expect(environment.isProduction()).to.be.false;
+    });
+
+    it('localhost without environment return false', () => {
+      sinon.stub(environment, 'instanceUrl').get(() => 'http://admin:pass@localhost');
+      expect(environment.isProduction()).to.be.false;
+    });
+
+    it('ip6-localhost and port environment return false', () => {
+      sinon.stub(environment, 'instanceUrl').get(() => 'http://admin:pass@ip6-localhost:5988');
+      expect(environment.isProduction()).to.be.false;
+    });
+
+    it('127.0.0.1 environment return false', () => {
+      sinon.stub(environment, 'instanceUrl').get(() => 'http://admin:pass@127.0.0.1:5988');
+      expect(environment.isProduction()).to.be.false;
+    });
+
+    it('::1 IPv6 loopback environment return false', () => {
+      sinon.stub(environment, 'instanceUrl').get(() => 'http://admin:pass@[::1]:5988');
+      expect(environment.isProduction()).to.be.false;
+    });
+
+    it('200.15.0.87 environment return true', () => {
+      sinon.stub(environment, 'instanceUrl').get(() => 'http://admin:pass@200.15.0.87:5988');
+      expect(environment.isProduction()).to.be.true;
+    });
+
+    it('prod.* environment return true', () => {
+      sinon.stub(environment, 'instanceUrl').get(() => 'http://admin:pass@prod.some.com:5988');
+      expect(environment.isProduction()).to.be.true;
+    });
+
+    it('prod.* environment return true', () => {
+      sinon.stub(environment, 'instanceUrl').get(() => 'https://parner-ab.medicmobile.org');
+      expect(environment.isProduction()).to.be.true;
+    });
+
+    it('dev.* environment return true', () => {
+      sinon.stub(environment, 'instanceUrl').get(() => 'http://admin:pass@dev.some.com:5988');
+      expect(environment.isProduction()).to.be.false;
+    });
+
+    it('staging.* environment return true', () => {
+      sinon.stub(environment, 'instanceUrl').get(() => 'http://admin:pass@staging.proj1.heroku.com:5988');
+      expect(environment.isProduction()).to.be.false;
+    });
+
+    it('dev-SOME.* environment return true', () => {
+      sinon.stub(environment, 'instanceUrl').get(() => 'https://some-demo.dev.medicmobile.org');
+      expect(environment.isProduction()).to.be.false;
+    });
+  });
+});

--- a/test/lib/exec-promise.spec.js
+++ b/test/lib/exec-promise.spec.js
@@ -1,0 +1,18 @@
+const { expect, assert } = require('chai');
+const exec = require('./../../src/lib/exec-promise');
+
+describe('exec-promise', () => {
+
+  it('execute command that does not exist raise a rejected promise', async () => {
+    try {
+      await exec('cmd-dont-exist.sh', 'some-arg');
+      assert.fail('Expected execution error');
+    } catch (err) {
+      expect(err).to.match(/cmd-dont-exist\.sh: not found/);
+    }
+  });
+
+  it('execute command that exist resolve in a not rejected promise', async () => {
+    await exec('node', '-h');   // No error is raised
+  });
+});

--- a/test/lib/exec-promise.spec.js
+++ b/test/lib/exec-promise.spec.js
@@ -1,16 +1,17 @@
 const { expect, assert } = require('chai');
 const exec = require('./../../src/lib/exec-promise');
+const { level } = require('./../../src/lib/log');
 
 describe('exec-promise', () => {
 
   it('execute command resolve in a promise with the standard output as a result', async () => {
-    const output = await exec('node', '-h');  // No error is raised
+    const output = await exec(level, 'node', '-h');  // No error is raised
     expect(output).to.match(/Usage: node/);
   });
 
   it('execute command with invalid args raise a rejected promise with output error as a result', async () => {
     try {
-      await exec('node', '--invalid-arg');
+      await exec(level, 'node', '--invalid-arg');
       assert.fail('Expected execution error');
     } catch (err) {
       expect(err).to.match(/node: bad option/);
@@ -19,7 +20,7 @@ describe('exec-promise', () => {
 
   it('execute command that does not exist raise a rejected promise', async () => {
     try {
-      await exec('cmd-dont-exist.sh', 'some-arg');
+      await exec(level, 'cmd-dont-exist.sh', 'some-arg');
       assert.fail('Expected execution error');
     } catch (err) {
       expect(err).to.match(/cmd-dont-exist\.sh: not found/);

--- a/test/lib/exec-promise.spec.js
+++ b/test/lib/exec-promise.spec.js
@@ -1,17 +1,16 @@
 const { expect, assert } = require('chai');
 const exec = require('./../../src/lib/exec-promise');
-const { level } = require('./../../src/lib/log');
 
 describe('exec-promise', () => {
 
   it('execute command resolve in a promise with the standard output as a result', async () => {
-    const output = await exec(level, 'node', '-h');  // No error is raised
+    const output = await exec([ 'node', '-h']);  // No error is raised
     expect(output).to.match(/Usage: node/);
   });
 
   it('execute command with invalid args raise a rejected promise with output error as a result', async () => {
     try {
-      await exec(level, 'node', '--invalid-arg');
+      await exec(['node', '--invalid-arg']);
       assert.fail('Expected execution error');
     } catch (err) {
       expect(err).to.match(/node: bad option/);
@@ -20,7 +19,7 @@ describe('exec-promise', () => {
 
   it('execute command that does not exist raise a rejected promise', async () => {
     try {
-      await exec(level, 'cmd-dont-exist.sh', 'some-arg');
+      await exec(['cmd-dont-exist.sh', 'some-arg']);
       assert.fail('Expected execution error');
     } catch (err) {
       expect(err).to.match(/cmd-dont-exist\.sh: not found/);

--- a/test/lib/exec-promise.spec.js
+++ b/test/lib/exec-promise.spec.js
@@ -1,28 +1,37 @@
 const { expect, assert } = require('chai');
-const exec = require('./../../src/lib/exec-promise');
+const rewire = require('rewire');
+const { Readable } = require('stream');
+
+const exec = rewire('./../../src/lib/exec-promise');
 
 describe('exec-promise', () => {
 
+  const readable = new Readable();  // dummy readable that at least does pipe
+  readable._read = () => {};
+
   it('execute command resolve in a promise with the standard output as a result', async () => {
+    exec.__set__('exec', (command, options, cb) => {
+      let sub = {};
+      sub.stdout = sub.stderr = readable;
+      cb(null, 'Usage: node [options] ...', null);
+      return sub;
+    });
     const output = await exec([ 'node', '-h']);  // No error is raised
     expect(output).to.match(/Usage: node/);
   });
 
-  it('execute command with invalid args raise a rejected promise with output error as a result', async () => {
+  it('execute command that output error raise a rejected promise with output error as a result', async () => {
+    exec.__set__('exec', (command, options, cb) => {
+      let sub = {};
+      sub.stdout = sub.stderr = readable;
+      cb(new Error(), null, 'node: bad option: --invalid-arg');
+      return sub;
+    });
     try {
       await exec(['node', '--invalid-arg']);
       assert.fail('Expected execution error');
     } catch (err) {
       expect(err).to.match(/node: bad option/);
-    }
-  });
-
-  it('execute command that does not exist raise a rejected promise', async () => {
-    try {
-      await exec(['cmd-dont-exist.sh', 'some-arg']);
-      assert.fail('Expected execution error');
-    } catch (err) {
-      expect(err).to.match(/cmd-dont-exist\.sh: not found/);
     }
   });
 });

--- a/test/lib/exec-promise.spec.js
+++ b/test/lib/exec-promise.spec.js
@@ -3,6 +3,20 @@ const exec = require('./../../src/lib/exec-promise');
 
 describe('exec-promise', () => {
 
+  it('execute command resolve in a promise with the standard output as a result', async () => {
+    const output = await exec('node', '-h');  // No error is raised
+    expect(output).to.match(/Usage: node/);
+  });
+
+  it('execute command with invalid args raise a rejected promise with output error as a result', async () => {
+    try {
+      await exec('node', '--invalid-arg');
+      assert.fail('Expected execution error');
+    } catch (err) {
+      expect(err).to.match(/node: bad option/);
+    }
+  });
+
   it('execute command that does not exist raise a rejected promise', async () => {
     try {
       await exec('cmd-dont-exist.sh', 'some-arg');
@@ -10,9 +24,5 @@ describe('exec-promise', () => {
     } catch (err) {
       expect(err).to.match(/cmd-dont-exist\.sh: not found/);
     }
-  });
-
-  it('execute command that exist resolve in a not rejected promise', async () => {
-    await exec('node', '-h');   // No error is raised
   });
 });

--- a/test/lib/git-exec.spec.js
+++ b/test/lib/git-exec.spec.js
@@ -1,9 +1,31 @@
-//const { expect, assert } = require('chai');
-const git = require('./../../src/lib/git-exec');
+const { expect } = require('chai');
+const rewire = require('rewire');
+
+const git = rewire('./../../src/lib/git-exec');
 
 describe('git-exec', () => {
 
-  it('execute `git status` do not raise any error', async () => {
-    await git.status();
+  it('`checkUpstream` with not upstream changes get empty result', async () => {
+    git.__set__('exec', () => Promise.resolve('0\t0'));
+    const result = await git.checkUpstream();
+    expect(result).to.eq('');
+  });
+
+  it('`checkUpstream` with branch changes get text with result', async () => {
+    git.__set__('exec', () => Promise.resolve('1\t0'));
+    const result = await git.checkUpstream();
+    expect(result).to.eq('branch is ahead upstream by 1 commit');
+  });
+
+  it('`checkUpstream` with upstream changes get text with result', async () => {
+    git.__set__('exec', () => Promise.resolve('0\t2'));
+    const result = await git.checkUpstream();
+    expect(result).to.eq('branch is behind upstream by 2 commits');
+  });
+
+  it('`checkUpstream` with upstream and local branch changes get text with result', async () => {
+    git.__set__('exec', () => Promise.resolve('2\t1'));
+    const result = await git.checkUpstream();
+    expect(result).to.eq('branch is behind upstream by 1 commit and ahead by 2 commits');
   });
 });

--- a/test/lib/git-exec.spec.js
+++ b/test/lib/git-exec.spec.js
@@ -1,0 +1,9 @@
+//const { expect, assert } = require('chai');
+const { gitStatus } = require('./../../src/lib/git-exec');
+
+describe('git-exec', () => {
+
+  it('execute `git status` do not raise any issue', async () => {
+    await gitStatus();
+  });
+});

--- a/test/lib/git-exec.spec.js
+++ b/test/lib/git-exec.spec.js
@@ -1,9 +1,9 @@
 //const { expect, assert } = require('chai');
-const { gitStatus } = require('./../../src/lib/git-exec');
+const git = require('./../../src/lib/git-exec');
 
 describe('git-exec', () => {
 
-  it('execute `git status` do not raise any issue', async () => {
-    await gitStatus();
+  it('execute `git status` do not raise any error', async () => {
+    await git.status();
   });
 });

--- a/test/lib/git-exec.spec.js
+++ b/test/lib/git-exec.spec.js
@@ -25,47 +25,51 @@ describe('git-exec', () => {
 
   it('`getUpstream` with no upstream repositories returns `null`', async () => {
     git.__set__('exec', () => Promise.resolve(''));
-    const result = await git.getUpstream();
+    const result = await git.getDefaultRemote();
     expect(result).to.be.null;
   });
 
   it('`getUpstream` with upstream repositories returns name`', async () => {
     git.__set__('exec', () => Promise.resolve('origin'));
-    const result = await git.getUpstream();
+    const result = await git.getDefaultRemote();
     expect(result).to.be.eq('origin');
   });
 
   it('`getUpstream` with multiple upstream repositories returns "origin" one`', async () => {
     git.__set__('exec', () => Promise.resolve('first-one\norigin\nother-repo-name'));
-    const result = await git.getUpstream();
+    const result = await git.getDefaultRemote();
     expect(result).to.be.eq('origin');
   });
 
   it('`getUpstream` with multiple upstream repositories returns one`', async () => {
     git.__set__('exec', () => Promise.resolve('first-one\nother-repo-name'));
-    const result = await git.getUpstream();
+    const result = await git.getDefaultRemote();
     expect(result).to.be.eq('first-one');
   });
 
-  it('`checkUpstream` with not upstream changes get empty result', async () => {
+  it('`checkUpstream` with no upstream changes get empty result', async () => {
+    git.__set__('getUpstream', () => Promise.resolve('origin/master'));
     git.__set__('exec', () => Promise.resolve('0\t0'));
     const result = await git.checkUpstream();
     expect(result).to.eq('');
   });
 
   it('`checkUpstream` with branch changes get text with result', async () => {
+    git.__set__('getUpstream', () => Promise.resolve('origin/master'));
     git.__set__('exec', () => Promise.resolve('1\t0'));
     const result = await git.checkUpstream();
     expect(result).to.eq('branch is ahead upstream by 1 commit');
   });
 
   it('`checkUpstream` with upstream changes get text with result', async () => {
+    git.__set__('getUpstream', () => Promise.resolve('origin/master'));
     git.__set__('exec', () => Promise.resolve('0\t2'));
     const result = await git.checkUpstream();
     expect(result).to.eq('branch is behind upstream by 2 commits');
   });
 
   it('`checkUpstream` with upstream and local branch changes get text with result', async () => {
+    git.__set__('getUpstream', () => Promise.resolve('origin/master'));
     git.__set__('exec', () => Promise.resolve('2\t1'));
     const result = await git.checkUpstream();
     expect(result).to.eq('branch is behind upstream by 1 commit and ahead by 2 commits');

--- a/test/lib/git-exec.spec.js
+++ b/test/lib/git-exec.spec.js
@@ -5,6 +5,48 @@ const git = rewire('./../../src/lib/git-exec');
 
 describe('git-exec', () => {
 
+  it('`status` returns `null` if git is not installed', async () => {
+    let result;
+    git.__set__('exec', () => Promise.reject('Command \'git\' not found, did you mean:'));
+    result = await git.status();
+    expect(result).to.be.null;
+
+    git.__set__('exec', () => Promise.reject('git: command not found'));
+    result = await git.status();
+    expect(result).to.be.null;
+  });
+
+  it('`status` returns `false` if the working directory does not have a git repository', async () => {
+    let result;
+    git.__set__('exec', () => Promise.reject('fatal: not a git repository (or any of the parent directories): .git'));
+    result = await git.status();
+    expect(result).to.be.null;
+  });
+
+  it('`getUpstream` with no upstream repositories returns `null`', async () => {
+    git.__set__('exec', () => Promise.resolve(''));
+    const result = await git.getUpstream();
+    expect(result).to.be.null;
+  });
+
+  it('`getUpstream` with upstream repositories returns name`', async () => {
+    git.__set__('exec', () => Promise.resolve('origin'));
+    const result = await git.getUpstream();
+    expect(result).to.be.eq('origin');
+  });
+
+  it('`getUpstream` with multiple upstream repositories returns "origin" one`', async () => {
+    git.__set__('exec', () => Promise.resolve('first-one\norigin\nother-repo-name'));
+    const result = await git.getUpstream();
+    expect(result).to.be.eq('origin');
+  });
+
+  it('`getUpstream` with multiple upstream repositories returns one`', async () => {
+    git.__set__('exec', () => Promise.resolve('first-one\nother-repo-name'));
+    const result = await git.getUpstream();
+    expect(result).to.be.eq('first-one');
+  });
+
   it('`checkUpstream` with not upstream changes get empty result', async () => {
     git.__set__('exec', () => Promise.resolve('0\t0'));
     const result = await git.checkUpstream();


### PR DESCRIPTION
# Description

Ticket: [medic-conf#64](https://github.com/medic/medic-conf/issues/64)

### Implementation details

- The new action is called `check-git`, I tried to follow the convention name used in other action names, but I'm not 100% convinced of the name used, so I open to rename it.
- The implementation check local changes not commited and upstream changes, asking the user in both cases whether to continue or not.
- Add some refactors in the `exec-promise` module to be able to get the stout stream content that a command outputs, and also add the ability to silent or not the output regarless of the global log configuration. The PR adds also some unit tests to cover the `exec-promise` module.
- Pin "pluralize" dependency used in new module `git-exec` that was a dependency of dependency already.

Here is an example of the changes in action:

![medic-conf-issue-64-check-git](https://user-images.githubusercontent.com/1608415/87452922-302bb500-c5d8-11ea-93d7-3c627e066f5e.png)

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalized: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.