### PR TITLE
254 check translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4714,6 +4714,14 @@
         }
       }
     },
+    "make-plural": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
+      "integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
     "mamacro": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
@@ -4824,6 +4832,26 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
+    },
+    "messageformat": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
+      "integrity": "sha512-uTzvsv0lTeQxYI2y1NPa1lItL5VRI8Gb93Y2K2ue5gBPyrbJxfDi/EYWxh2PKv5yO42AJeeqblS9MJSh/IEk4w==",
+      "requires": {
+        "make-plural": "^4.3.0",
+        "messageformat-formatters": "^2.0.1",
+        "messageformat-parser": "^4.1.2"
+      }
+    },
+    "messageformat-formatters": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/messageformat-formatters/-/messageformat-formatters-2.0.1.tgz",
+      "integrity": "sha512-E/lQRXhtHwGuiQjI7qxkLp8AHbMD5r2217XNe/SREbBlSawe0lOqsFb7rflZJmlQFSULNLIqlcjjsCPlB3m3Mg=="
+    },
+    "messageformat-parser": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
+      "integrity": "sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg=="
     },
     "methods": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "json-diff": "^0.5.4",
     "json-stringify-safe": "^5.0.1",
     "json2csv": "^4.5.1",
+    "messageformat": "^2.3.0",
     "mime-types": "^2.1.27",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "json-diff": "^0.5.4",
     "json-stringify-safe": "^5.0.1",
     "json2csv": "^4.5.1",
+    "lodash": "^4.17.15",
     "messageformat": "^2.3.0",
     "mime-types": "^2.1.27",
     "minimist": "^1.2.0",

--- a/src/fn/upload-custom-translations.js
+++ b/src/fn/upload-custom-translations.js
@@ -122,7 +122,9 @@ function checkTranslations(translations, lang, templatePlaceholders) {
     log.warn(`Cannot check '${lang}' translations: ${e.message}`);
   }
   const placeholders = extractPlaceholdersFromTranslations(translations);
-  let formatErrorsFound = 0,  placeholderErrorsFound = 0, emptiesFound = 0;
+  let formatErrorsFound = 0;
+  let placeholderErrorsFound = 0;
+  let emptiesFound = 0;
   for (const [msgKey, msgSrc] of Object.entries(translations)) {
     if (!msgSrc) {
       emptiesFound++;

--- a/src/fn/upload-custom-translations.js
+++ b/src/fn/upload-custom-translations.js
@@ -15,6 +15,8 @@ const FILE_MATCHER = /^messages-.*\.properties$/;
 const EN_FILE = 'messages-en.properties';
 const EX_FILE = 'messages-ex.properties';
 
+const MUSTACHE_MATCHER = /{{[\s\w.#^/'|]+}}/g;
+
 const MFORMAT = new MessageFormat('en');
 const transErrorsMsg = MFORMAT
   .compile('There {ERRORS, plural, one{was 1 error} other{were # errors}} trying to compile');
@@ -128,7 +130,7 @@ function checkTranslations(translations, lang, templatePlaceholders) {
   for (const [msgKey, msgSrc] of Object.entries(translations)) {
     if (!msgSrc) {
       emptiesFound++;
-    } else if (/{{[\s\w.#^/'|]+}}/.test(msgSrc)) {
+    } else if (MUSTACHE_MATCHER.test(msgSrc)) {
       if (templatePlaceholders) {
         const placeholder = placeholders[msgKey];
         if (placeholder) {
@@ -172,7 +174,7 @@ function extractPlaceholdersFromTranslations(translations, extraPlaceholders = {
   // Extract from github.com/medic/cht-core/blob/master/scripts/poe/lib/utils.js
   const result = {};
   for (const [msgKey, msgSrc] of Object.entries(translations)) {
-    let placeholders = typeof msgSrc === 'string' ? msgSrc.match(/{{[\s\w.#^/'|]+}}/g) : null;
+    let placeholders = typeof msgSrc === 'string' ? msgSrc.match(MUSTACHE_MATCHER) : null;
     if (placeholders) {
       placeholders = placeholders
         .sort()

--- a/src/fn/upload-custom-translations.js
+++ b/src/fn/upload-custom-translations.js
@@ -16,6 +16,8 @@ const FILE_MATCHER = /^messages-.*\.properties$/;
 const EN_FILE = 'messages-en.properties';
 const EX_FILE = 'messages-ex.properties';
 
+const MUSTACHE_MATCHER = /{{[\s\w.#^/'|]+}}/g;
+
 const MFORMAT = new MessageFormat('en');
 const transErrorsMsg = MFORMAT
   .compile('There {ERRORS, plural, one{was 1 error} other{were # errors}} trying to compile');
@@ -129,7 +131,7 @@ function checkTranslations(translations, lang, templatePlaceholders) {
   for (const [msgKey, msgSrc] of Object.entries(translations)) {
     if (!msgSrc) {
       emptiesFound++;
-    } else if (/{{[\s\w.#^/'|]+}}/.test(msgSrc)) {
+    } else if (msgSrc.match(MUSTACHE_MATCHER) !== null) {
       if (templatePlaceholders) {
         const msgPlaceholders = placeholders[msgKey];
         if (msgPlaceholders) {
@@ -173,7 +175,7 @@ function extractPlaceholdersFromTranslations(translations, extraPlaceholders = {
   // Extract from github.com/medic/cht-core/blob/master/scripts/poe/lib/utils.js
   const result = {};
   for (const [msgKey, msgSrc] of Object.entries(translations)) {
-    let placeholders = typeof msgSrc === 'string' ? msgSrc.match(/{{[\s\w.#^/'|]+}}/g) : null;
+    let placeholders = typeof msgSrc === 'string' ? msgSrc.match(MUSTACHE_MATCHER) : null;
     if (placeholders) {
       result[msgKey] = _.uniq(placeholders.concat(extraPlaceholders[msgKey] || []));
     } else if (extraPlaceholders[msgKey]) {

--- a/src/fn/upload-custom-translations.js
+++ b/src/fn/upload-custom-translations.js
@@ -175,8 +175,7 @@ function extractPlaceholdersFromTranslations(translations, extraPlaceholders = {
   for (const [msgKey, msgSrc] of Object.entries(translations)) {
     let placeholders = typeof msgSrc === 'string' ? msgSrc.match(/{{[\s\w.#^/'|]+}}/g) : null;
     if (placeholders) {
-      const msgExtraPlaceholders = extraPlaceholders[msgKey] ? extraPlaceholders[msgKey] : [];
-      result[msgKey] = _.uniq(placeholders.concat(msgExtraPlaceholders));
+      result[msgKey] = _.uniq(placeholders.concat(extraPlaceholders[msgKey] || []));
     } else if (extraPlaceholders[msgKey]) {
       result[msgKey] = extraPlaceholders[msgKey];
     }

--- a/src/fn/upload-custom-translations.js
+++ b/src/fn/upload-custom-translations.js
@@ -12,6 +12,8 @@ const MessageFormat = require('messageformat');
 
 const FILE_MATCHER = /^messages-.*\.properties$/;
 
+const HAS_MUSTACHE_MATCHER = /{{[\s\w.]+}}/;
+
 const transErrorsMsg = new MessageFormat('en')
   .compile('There {ERRORS, plural, one{was 1 error} other{were # errors}} trying to compile the translations');
 
@@ -102,8 +104,10 @@ function checkTranslations(translations, languageCode) {
       try {
         mf.compile(msgSrc);
       } catch (e) {
-        error(`Cannot compile '${languageCode}' translation ${msgKey} = '${msgSrc}' : ` + e.message);
-        foundError++;
+        if (!HAS_MUSTACHE_MATCHER.test(msgSrc)) {
+          error(`Cannot compile '${languageCode}' translation ${msgKey} = '${msgSrc}' : ` + e.message);
+          foundError++;
+        }
       }
     }
   }

--- a/src/fn/upload-custom-translations.js
+++ b/src/fn/upload-custom-translations.js
@@ -15,8 +15,6 @@ const FILE_MATCHER = /^messages-.*\.properties$/;
 const EN_FILE = 'messages-en.properties';
 const EX_FILE = 'messages-ex.properties';
 
-const MUSTACHE_MATCHER = /{{[\s\w.#^/'|]+}}/g;
-
 const MFORMAT = new MessageFormat('en');
 const transErrorsMsg = MFORMAT
   .compile('There {ERRORS, plural, one{was 1 error} other{were # errors}} trying to compile');
@@ -130,7 +128,7 @@ function checkTranslations(translations, lang, templatePlaceholders) {
   for (const [msgKey, msgSrc] of Object.entries(translations)) {
     if (!msgSrc) {
       emptiesFound++;
-    } else if (MUSTACHE_MATCHER.test(msgSrc)) {
+    } else if (/{{[\s\w.#^/'|]+}}/.test(msgSrc)) {
       if (templatePlaceholders) {
         const placeholder = placeholders[msgKey];
         if (placeholder) {
@@ -174,7 +172,7 @@ function extractPlaceholdersFromTranslations(translations, extraPlaceholders = {
   // Extract from github.com/medic/cht-core/blob/master/scripts/poe/lib/utils.js
   const result = {};
   for (const [msgKey, msgSrc] of Object.entries(translations)) {
-    let placeholders = typeof msgSrc === 'string' ? msgSrc.match(MUSTACHE_MATCHER) : null;
+    let placeholders = typeof msgSrc === 'string' ? msgSrc.match(/{{[\s\w.#^/'|]+}}/g) : null;
     if (placeholders) {
       placeholders = placeholders
         .sort()

--- a/src/fn/upload-custom-translations.js
+++ b/src/fn/upload-custom-translations.js
@@ -126,7 +126,7 @@ function checkTranslations(translations, lang, templatePlaceholders) {
   for (const [msgKey, msgSrc] of Object.entries(translations)) {
     if (!msgSrc) {
       emptiesFound++;
-    } else if (/{{[\s\w.#^/]+}}/.test(msgSrc)) {
+    } else if (/{{[\s\w.#^/'|]+}}/.test(msgSrc)) {
       if (templatePlaceholders) {
         const placeholder = placeholders[msgKey];
         if (placeholder) {
@@ -170,7 +170,7 @@ function extractPlaceholdersFromTranslations(translations, extraPlaceholders = {
   // Extract from github.com/medic/cht-core/blob/master/scripts/poe/lib/utils.js
   const result = {};
   for (const [msgKey, msgSrc] of Object.entries(translations)) {
-    let placeholders = typeof msgSrc === 'string' ? msgSrc.match(/{{[\s\w.#^/]+}}/g) : null;
+    let placeholders = typeof msgSrc === 'string' ? msgSrc.match(/{{[\s\w.#^/'|]+}}/g) : null;
     if (placeholders) {
       placeholders = placeholders
         .sort()

--- a/test/data/upload-custom-translations/contains-empty-messages/translations/messages-en.properties
+++ b/test/data/upload-custom-translations/contains-empty-messages/translations/messages-en.properties
@@ -1,0 +1,2 @@
+some.words = one equals one
+empty.msg =

--- a/test/data/upload-custom-translations/contains-messageformat-wrong/translations/messages-en.properties
+++ b/test/data/upload-custom-translations/contains-messageformat-wrong/translations/messages-en.properties
@@ -1,0 +1,3 @@
+some.words = one equals one
+# Next key has missed "," after the "plural" key
+n.month = {MONTHS, plural one{1 month} other{\# months}}

--- a/test/data/upload-custom-translations/contains-messageformat/translations/messages-en.properties
+++ b/test/data/upload-custom-translations/contains-messageformat/translations/messages-en.properties
@@ -1,0 +1,2 @@
+some.words = one equals one
+n.month = {MONTHS, plural, one{1 month} other{\# months}}

--- a/test/data/upload-custom-translations/contains-placeholder-wrong/translations/messages-en.properties
+++ b/test/data/upload-custom-translations/contains-placeholder-wrong/translations/messages-en.properties
@@ -1,0 +1,1 @@
+Number\ in\ month = {{count}} in {{month}}

--- a/test/data/upload-custom-translations/contains-placeholder-wrong/translations/messages-es.properties
+++ b/test/data/upload-custom-translations/contains-placeholder-wrong/translations/messages-es.properties
@@ -1,0 +1,1 @@
+Number\ in\ month = {{count}} en {{meses}}

--- a/test/data/upload-custom-translations/contains-placeholder/translations/messages-en.properties
+++ b/test/data/upload-custom-translations/contains-placeholder/translations/messages-en.properties
@@ -1,0 +1,1 @@
+Number\ in\ month = {{count}} in {{month}}

--- a/test/data/upload-custom-translations/contains-placeholder/translations/messages-es.properties
+++ b/test/data/upload-custom-translations/contains-placeholder/translations/messages-es.properties
@@ -1,0 +1,1 @@
+Number\ in\ month = {{count}} en {{month}}

--- a/test/fn/upload-custom-translations.spec.js
+++ b/test/fn/upload-custom-translations.spec.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 const readline = require('readline-sync');
 const api = require('../api-stub');
 const environment = require('../../src/lib/environment');
+const log = require('../../src/lib/log');
 const testProjectDir = './data/upload-custom-translations/';
 const uploadCustomTranslations = require('../../src/fn/upload-custom-translations').execute;
 
@@ -43,7 +44,7 @@ describe('upload-custom-translations', () => {
     });
 
     it('should upload simple translations', () => {
-      mockTestDir(`simple`);
+      mockTestDir('simple');
       return uploadCustomTranslations()
         .then(() => expectTranslationDocs('en'))
         .then(() => getTranslationDoc('en'))
@@ -55,7 +56,7 @@ describe('upload-custom-translations', () => {
     });
 
     it('should upload translations for multiple languages', () => {
-      mockTestDir(`multi-lang`);
+      mockTestDir('multi-lang');
       return uploadCustomTranslations()
         .then(() => expectTranslationDocs('en', 'fr'))
         .then(() => getTranslationDoc('en'))
@@ -75,7 +76,7 @@ describe('upload-custom-translations', () => {
     });
 
     it('should upload translations containing equals signs', () => {
-      mockTestDir(`contains-equals`);
+      mockTestDir('contains-equals');
       return uploadCustomTranslations()
         .then(() => expectTranslationDocs('en'))
         .then(() => getTranslationDoc('en'))
@@ -90,7 +91,7 @@ describe('upload-custom-translations', () => {
     });
 
     it('should work correctly when falling back to testing messages-en', () => {
-      mockTestDir(`custom-lang`);
+      mockTestDir('custom-lang');
       return api.db
         .put({
           _id: 'messages-en',
@@ -116,7 +117,7 @@ describe('upload-custom-translations', () => {
     });
 
     it('should set default name for unknown language', () => {
-      mockTestDir(`unknown-lang`);
+      mockTestDir('unknown-lang');
       return uploadCustomTranslations()
         .then(() => expectTranslationDocs('qp'))
         .then(() => getTranslationDoc('qp'))
@@ -133,11 +134,11 @@ describe('upload-custom-translations', () => {
         readline.keyInSelect = () => 0;
         return api.db.put({ _id: '_design/medic-client', deploy_info: { version: '3.0.0' } });
       });
-      
+
       it('should upload simple translations', () => {
         // api/deploy-info endpoint doesn't exist
         api.giveResponses({ status: 404, body: { error: 'not_found' } });
-        mockTestDir(`simple`);
+        mockTestDir('simple');
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs('en'))
           .then(() => getTranslationDoc('en'))
@@ -151,7 +152,7 @@ describe('upload-custom-translations', () => {
       it('should upload translations for multiple languages', () => {
         // api/deploy-info endpoint doesn't exist
         api.giveResponses({ status: 404, body: { error: 'not_found' } });
-        mockTestDir(`multi-lang`);
+        mockTestDir('multi-lang');
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs('en', 'fr'))
           .then(() => getTranslationDoc('en'))
@@ -173,7 +174,7 @@ describe('upload-custom-translations', () => {
       it('should upload translations containing equals signs', () => {
         // api/deploy-info endpoint doesn't exist
         api.giveResponses({ status: 404, body: { error: 'not_found' } });
-        mockTestDir(`contains-equals`);
+        mockTestDir('contains-equals');
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs('en'))
           .then(() => getTranslationDoc('en'))
@@ -188,7 +189,7 @@ describe('upload-custom-translations', () => {
       });
 
       it('should merge with existent translations', () => {
-        mockTestDir(`with-customs`);
+        mockTestDir('with-customs');
         return api.db
           .put({
             _id: 'messages-en',
@@ -208,7 +209,7 @@ describe('upload-custom-translations', () => {
       });
 
       it('should crash for malformed translation files', () => {
-        mockTestDir(`with-customs`);
+        mockTestDir('with-customs');
         return api.db
           .put({
             _id: 'messages-en',
@@ -223,7 +224,7 @@ describe('upload-custom-translations', () => {
       });
 
       it('should set default name for unknown language', () => {
-        mockTestDir(`unknown-lang`);
+        mockTestDir('unknown-lang');
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs('qp'))
           .then(() => getTranslationDoc('qp'))
@@ -239,7 +240,7 @@ describe('upload-custom-translations', () => {
       it('should upload simple translations', () => {
         // api/deploy-info endpoint doesn't exist
         api.giveResponses({ status: 404, body: { error: 'not_found' } });
-        mockTestDir(`simple`);
+        mockTestDir('simple');
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs('en'))
           .then(() => getTranslationDoc('en'))
@@ -253,7 +254,7 @@ describe('upload-custom-translations', () => {
       it('should upload translations for multiple languages', () => {
         // api/deploy-info endpoint doesn't exist
         api.giveResponses({ status: 404, body: { error: 'not_found' } });
-        mockTestDir(`multi-lang`);
+        mockTestDir('multi-lang');
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs('en', 'fr'))
           .then(() => getTranslationDoc('en'))
@@ -275,7 +276,7 @@ describe('upload-custom-translations', () => {
       it('should upload translations containing equals signs', () => {
         // api/deploy-info endpoint doesn't exist
         api.giveResponses({ status: 404, body: { error: 'not_found' } });
-        mockTestDir(`contains-equals`);
+        mockTestDir('contains-equals');
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs('en'))
           .then(() => getTranslationDoc('en'))
@@ -290,7 +291,7 @@ describe('upload-custom-translations', () => {
       });
 
       it('should replace existent custom values', () => {
-        mockTestDir(`with-customs`);
+        mockTestDir('with-customs');
         return api.db
           .put({
             _id: 'messages-en',
@@ -311,7 +312,7 @@ describe('upload-custom-translations', () => {
       });
 
       it('should replace delete custom values', () => {
-        mockTestDir(`no-customs`);
+        mockTestDir('no-customs');
         return api.db
           .put({
             _id: 'messages-en',
@@ -334,7 +335,7 @@ describe('upload-custom-translations', () => {
       it('should work correctly when falling back to testing messages-en', () => {
         // api/deploy-info endpoint doesn't exist
         api.giveResponses({ status: 404, body: { error: 'not_found' } });
-        mockTestDir(`custom-lang`);
+        mockTestDir('custom-lang');
         // for *some* reason, medic-client doesn't have deploy-info
         return api.db
           .get('_design/medic-client')
@@ -366,7 +367,7 @@ describe('upload-custom-translations', () => {
       });
 
       it('should set default name for unknown language', () => {
-        mockTestDir(`unknown-lang`);
+        mockTestDir('unknown-lang');
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs('qp'))
           .then(() => getTranslationDoc('qp'))
@@ -384,7 +385,7 @@ describe('upload-custom-translations', () => {
       });
 
       it('should upload simple translations', () => {
-        mockTestDir(`simple`);
+        mockTestDir('simple');
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs('en'))
           .then(() => getTranslationDoc('en'))
@@ -396,7 +397,7 @@ describe('upload-custom-translations', () => {
       });
 
       it('should upload translations for multiple languages', () => {
-        mockTestDir(`multi-lang`);
+        mockTestDir('multi-lang');
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs('en', 'fr'))
           .then(() => getTranslationDoc('en'))
@@ -416,7 +417,7 @@ describe('upload-custom-translations', () => {
       });
 
       it('should upload translations containing equals signs', () => {
-        mockTestDir(`contains-equals`);
+        mockTestDir('contains-equals');
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs('en'))
           .then(() => getTranslationDoc('en'))
@@ -431,7 +432,7 @@ describe('upload-custom-translations', () => {
       });
 
       it('should set default name for unknown language', () => {
-        mockTestDir(`unknown-lang`);
+        mockTestDir('unknown-lang');
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs('qp'))
           .then(() => getTranslationDoc('qp'))
@@ -441,7 +442,7 @@ describe('upload-custom-translations', () => {
       });
 
       it('should properly upload translations containing escaped exclamation marks', () => {
-        mockTestDir(`escaped-exclamation`);
+        mockTestDir('escaped-exclamation');
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs('en'))
           .then(() => getTranslationDoc('en'))
@@ -455,13 +456,46 @@ describe('upload-custom-translations', () => {
           });
       });
 
+      it('should upload translations containing valid messageformat', () => {
+        mockTestDir('contains-messageformat');
+        return uploadCustomTranslations()
+          .then(() => expectTranslationDocs('en'))
+          .then(() => getTranslationDoc('en'))
+          .then(messagesEn => {
+            assert.deepEqual(messagesEn.custom, {
+              'some.words': 'one equals one',
+              'n.month': '{MONTHS, plural, one{1 month} other{# months}}',
+            });
+          });
+      });
+
+      it('upload translations containing empty messages raises warn logs', () => {
+        mockTestDir('contains-empty-messages');
+        sinon.replace(log, 'warn', sinon.fake());
+        return uploadCustomTranslations()
+          .then(() => {
+            assert(log.warn.lastCall.calledWithMatch('Empty \'en\' translation for \'empty.msg\' key'));
+          });
+      });
+
+      it('upload translations containing invalid messageformat raises error logs and exit', () => {
+        mockTestDir('contains-messageformat-wrong');
+        sinon.replace(log, 'error', sinon.fake());
+        sinon.replace(process, 'exit', sinon.fake());
+        return uploadCustomTranslations()
+          .then(() => {
+            assert(log.error.lastCall.calledWithMatch('There was 1 error trying to compile the translations'));
+            assert(process.exit.calledOnce);
+          });
+      });
+
     });
 
 
   });
 
   it('should crash for invalid language code', () => {
-    mockTestDir(`invalid-lang`);
+    mockTestDir('invalid-lang');
     return uploadCustomTranslations()
       .then(() => {
         throw new Error('ensures uploadCustomTranslations throws');


### PR DESCRIPTION
Ticket: https://github.com/medic/medic-conf/issues/254

### Check translations content before push

- Add "messageformat" module to check translations that use that syntax
- If a translation use the "MessageFormat" syntax check the translation and fails the process if there is an error
- If a translation is empty just warn the the lack of the translation

#### Warnings

This is how warnings are displayed when empty messages are found (the upload process is not interrupted):

```
$ medic-conf upload-custom-translations --local
INFO Using local url from COUCH_URL environment variable: http://admin:****@localhost:5984/medic 
INFO Processing config in default. 
INFO Actions:
     - upload-custom-translations
INFO Starting action: upload-custom-translations…
WARN Empty 'en' translation for 'report.delivery.babys_condition.baby_repeat' key
WARN Empty 'en' translation for 'report.delivery.pnc_visits.who_note' key
...
```

#### Errors

MessageFormat wrong syntax does raise errors and exit the process:

```
$ medic-conf upload-custom-translations --local
INFO Using local url from COUCH_URL environment variable: http://admin:****@localhost:5984/medic
INFO Processing config in default.
INFO Actions:
     - upload-custom-translations
INFO Starting action: upload-custom-translations…
ERROR Cannot compile 'en' translation n.month = '{MONTHS, plural one{1 month} other{# months}}' : Expected "," but "o" found.
ERROR Cannot compile 'en' translation n.day = '{DAYS, plural, one{1 day} other{# days}' : Expected "=", "}", or identifier but end of input found.
ERROR There were 2 errors trying to compile the translations
```