### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'Type: Bug'
+assignees: ''
+
+---
+
+**Important**: This is a public repository. Anyone in the world can see what's posted here. If you are posting screenshots or log files, please **carefully examine them for** the presence of any kind of **protected health information** (PHI). Images or logs containing PHI _must_ be posted in fully-redacted form, with no visible PHI.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+If applicable, include the medic-conf output, server logs, and/or browser logs.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment**
+- Instance: (eg: alpha.dev.medicmobile.org, etc)
+- Client platform: (eg: Windows, MacOS, Linux)
+- medic-conf version: (eg: 2.15.0, 3.0.0, etc)
+- cht-core version: (eg: 2.15.0, 3.0.0, etc)
+
+**Additional context**
+Add any other context about the problem here. What have you tried? Is there a workaround?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'Type: Feature'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,0 +1,20 @@
+---
+name: Improvement
+about: Suggest something to make an existing feature better
+title: ''
+labels: 'Type: Improvement'
+assignees: ''
+
+---
+
+**What feature do you want to improve?**
+A clear and concise description of what the problem is. Ex. It would be better to [...]
+
+**Describe the improvement you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/technical_issue.md
+++ b/.github/ISSUE_TEMPLATE/technical_issue.md
@@ -1,0 +1,17 @@
+---
+name: Technical issue
+about: Suggest an improvement users won't notice
+title: ''
+labels: 'Type: Technical issue'
+assignees: ''
+
+---
+
+**Describe the issue**
+A clear and concise description of what the problem is.
+
+**Describe the improvement you'd like**
+A clear and concise description of what you want to change.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+# Description
+
+[description]
+
+medic/medic-conf#[number]
+
+# Code review items
+
+- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
+- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
+- Tested: Unit and/or integration tests where appropriate
+- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.
+
+# License
+
+The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.


### PR DESCRIPTION
Most of the issue templates are just copied from cht-core with minor modifications.