### PR TITLE
comments and urls in tasks exception warning

### DIFF
--- a/src/lib/compile-nools-rules.js
+++ b/src/lib/compile-nools-rules.js
@@ -48,6 +48,9 @@ const compileDeclarativeFiles = async (projectDir, options) => {
   const baseEslintPath = path.join(__dirname, '../nools/.eslintrc');
   
   const code = await pack(projectDir, pathToDeclarativeLib, baseEslintPath, options);
+  if (code.match(/\/\/(.*)/g)) {
+    throw new Error(`Settings should not have comments or urls`);
+  }
   return `define Target { _id: null, contact: null, deleted: null, type: null, pass: null, date: null, groupBy: null }
 define Contact { contact: null, reports: null, tasks: null }
 define Task { _id: null, deleted: null, doc: null, contact: null, icon: null, date: null, readyStart: null, readyEnd: null, title: null, fields: null, resolved: null, priority: null, priorityLabel: null, reports: null, actions: null }

--- a/test/lib/compile-nools-rules.spec.js
+++ b/test/lib/compile-nools-rules.spec.js
@@ -38,7 +38,7 @@ describe('compile nools-rules', () => {
           var today = new Date();
         }
       }`);
-    
+
     return compileNoolsRules
       .__with__(mocks)(() => compileNoolsRules('/project', { minifyScripts: true }))
       .then(actual => {
@@ -101,6 +101,19 @@ describe('compile nools-rules', () => {
       .then(() => assert.fail('Expected compilation error'))
       .catch(err => {
         expect(err.message).to.include('tasks.js');
+      });
+  });
+
+  it('comments and urls in fields yields exception', () => {
+    const mocks = genMocks();
+    mocks.fs.exists
+      .withArgs('/rules.nools.js').returns(true);
+    mocks.fs.read.withArgs('/rules.nools.js').returns('define Task {_id: null, title: "http://foo.bar.com"}');
+
+    return compileNoolsRules.__with__(mocks)(() => compileNoolsRules('/'))
+      .then(() => assert.fail('Expected compilation error'))
+      .catch(err => {
+        expect(err.message).to.include('Settings should not have comments or urls');
       });
   });
 });

--- a/test/lib/compile-nools-rules.spec.js
+++ b/test/lib/compile-nools-rules.spec.js
@@ -103,18 +103,4 @@ describe('compile nools-rules', () => {
         expect(err.message).to.include('tasks.js');
       });
   });
-
-  it('comments in fields yields exception', () => {
-    const mocks = genMocks();
-    mocks.fs.exists
-      .withArgs('/rules.nools.js').returns(true)
-      .withArgs('/tasks.js').returns(true);
-    mocks.fs.read.withArgs('/rules.nools.js').returns('define Task {_id: null, title: "http://www.foo.com"}');
-    
-    return compileNoolsRules.__with__(mocks)(() => compileNoolsRules('/'))
-      .then(() => assert.fail('Expected compilation error'))
-      .catch(err => {
-        expect(err.message).to.include('Settings should not have comments or urls');
-      });
-  });
 });

--- a/test/lib/compile-nools-rules.spec.js
+++ b/test/lib/compile-nools-rules.spec.js
@@ -103,4 +103,18 @@ describe('compile nools-rules', () => {
         expect(err.message).to.include('tasks.js');
       });
   });
+
+  it('comments in fields yields exception', () => {
+    const mocks = genMocks();
+    mocks.fs.exists
+      .withArgs('/rules.nools.js').returns(true)
+      .withArgs('/tasks.js').returns(true);
+    mocks.fs.read.withArgs('/rules.nools.js').returns('define Task {_id: null, title: "http://www.foo.com"}');
+    
+    return compileNoolsRules.__with__(mocks)(() => compileNoolsRules('/'))
+      .then(() => assert.fail('Expected compilation error'))
+      .catch(err => {
+        expect(err.message).to.include('Settings should not have comments or urls');
+      });
+  });
 });


### PR DESCRIPTION
https://github.com/medic/cht-core/issues/6506

Throw exception in medic conf during upload when tasks.js contains comments or urls.