### PR TITLE
164 applies to type optional

### DIFF
--- a/src/contact-summary/contact-summary-emitter.js
+++ b/src/contact-summary/contact-summary-emitter.js
@@ -32,7 +32,7 @@ function emitter(contactSummary, contact, reports) {
       throw new Error("You cannot set appliesToType to an array which includes the type 'report' and another type.");
     }
     
-    if (appliesToType.includes('report') || appliesToType.length === 0) {
+    if (appliesToType.includes('report') || (appliesToType.length === 0 && typeof card.fields === 'function')) {
       for (idx1=0; idx1<reports.length; ++idx1) {
         r = reports[idx1];
         if (!isReportValid(r)) {

--- a/src/contact-summary/contact-summary-emitter.js
+++ b/src/contact-summary/contact-summary-emitter.js
@@ -32,7 +32,7 @@ function emitter(contactSummary, contact, reports) {
       throw new Error("You cannot set appliesToType to an array which includes the type 'report' and another type.");
     }
     
-    if (appliesToType.includes('report') || (appliesToType.length === 0 && typeof card.fields === 'function')) {
+    if (appliesToType.includes('report')) {
       for (idx1=0; idx1<reports.length; ++idx1) {
         r = reports[idx1];
         if (!isReportValid(r)) {
@@ -84,9 +84,6 @@ function execAppliesIf(prop, report) {
 }
 
 function addCard(card, context, r) {
-  if (typeof card.fields === 'function' && arguments.length < 3) {
-    return;
-  }
   if (!execAppliesIf(card.appliesIf, r)) {
     return;
   }

--- a/src/contact-summary/contact-summary-emitter.js
+++ b/src/contact-summary/contact-summary-emitter.js
@@ -12,7 +12,7 @@ function emitter(contactSummary, contact, reports) {
       var appliesToNotType = appliesToType.filter(function(type) {
         return type && type.charAt(0) === '!';
       });
-      if (appliesToType.includes(contactType) ||
+      if (appliesToType.length === 0 || appliesToType.includes(contactType) ||
           (appliesToNotType.length > 0 && !appliesToNotType.includes('!' + contactType))) {
         if (!f.appliesIf || f.appliesIf()) {
           delete f.appliesToType;
@@ -32,7 +32,7 @@ function emitter(contactSummary, contact, reports) {
       throw new Error("You cannot set appliesToType to an array which includes the type 'report' and another type.");
     }
     
-    if (appliesToType.includes('report')) {
+    if (appliesToType.includes('report') || appliesToType.length === 0) {
       for (idx1=0; idx1<reports.length; ++idx1) {
         r = reports[idx1];
         if (!isReportValid(r)) {
@@ -45,7 +45,7 @@ function emitter(contactSummary, contact, reports) {
         }
       }
     } else {
-      if (!appliesToType.includes(contactType)) {
+      if (!appliesToType.includes(contactType) && appliesToType.length > 0) {
         return;
       }
 
@@ -63,6 +63,9 @@ function emitter(contactSummary, contact, reports) {
 }
 
 function convertToArray(appliesToType) {
+  if (!appliesToType) {
+    return [];
+  }
   return Array.isArray(appliesToType) ? appliesToType : [appliesToType];  
 }
 
@@ -81,6 +84,9 @@ function execAppliesIf(prop, report) {
 }
 
 function addCard(card, context, r) {
+  if (typeof card.fields === 'function' && arguments.length < 3) {
+    return;
+  }
   if (!execAppliesIf(card.appliesIf, r)) {
     return;
   }

--- a/test/contact-summary/contact-summary-emitter.spec.js
+++ b/test/contact-summary/contact-summary-emitter.spec.js
@@ -66,7 +66,7 @@ describe('contact-summary-emitter', function() {
       assert.equal(appliesIf.callCount, 0);
     });
 
-    it('does not add cards with undefined appliesToType and existing contact type', () => {
+    it('adds cards with undefined appliesToType and existing contact type', () => {
       const appliesIf = sinon.stub().returns(false);
       const cards = [
         { appliesIf },
@@ -74,7 +74,7 @@ describe('contact-summary-emitter', function() {
       const report = { report: true };
       emitter({ cards }, { type: 'x' }, [report]);
 
-      assert.equal(appliesIf.callCount, 0);
+      assert.equal(appliesIf.callCount, 1);
     });
 
     it('adds cards with undefined appliesToType and undefined contact type', () => {
@@ -147,15 +147,15 @@ describe('contact-summary-emitter', function() {
       expect(result.fields).to.deep.eq([]);
     });
 
-    it('does not add fields with undefined appliesToType and defined contact type', () => {
+    it('adds fields with undefined appliesToType and defined contact type', () => {
       const appliesIf = sinon.stub().returns(true);
       const fields = [
-        { appliesIf },
+        { appliesIf, label: 'label' },
       ];
       const report = { report: true };
       const result = emitter({ fields }, { type: 'r' }, [report]);
 
-      expect(result.fields).to.deep.eq([]);
+      expect(result.fields).to.deep.eq([{ label: 'label' }]);
     });
 
     it('does add fields with undefined appliesToType and undefined contact type', () => {


### PR DESCRIPTION
# Description

This PR makes a change to how `appliesToType` is processed such that if it is absent tthere is no effect and cards and fields should be displayed by default.

medic/medic-conf#164

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
