### PR TITLE
Remove spurious warning

### DIFF
--- a/src/lib/upload-forms.js
+++ b/src/lib/upload-forms.js
@@ -8,7 +8,7 @@ const insertOrReplace = require('./insert-or-replace');
 const pouch = require('./db');
 const warnUploadOverwrite = require('./warn-upload-overwrite');
 
-const SUPPORTED_PROPERTIES = ['context', 'icon', 'title', 'xml2sms', 'subject_key'];
+const SUPPORTED_PROPERTIES = ['context', 'icon', 'title', 'xml2sms', 'subject_key', 'hidden_fields'];
 
 module.exports = (projectDir, subDirectory, options) => {
   const db = pouch();

--- a/test/data/lib/upload-forms/merge-properties/forms/example.properties.json
+++ b/test/data/lib/upload-forms/merge-properties/forms/example.properties.json
@@ -7,5 +7,6 @@
   "xml2sms": "hello world",
   "internalId": "different",
   "subject_key": "some.translation.key",
-  "unknown": true
+  "unknown": true,
+  "hidden_fields": ["hidden"]
 }

--- a/test/lib/upload-forms.spec.js
+++ b/test/lib/upload-forms.spec.js
@@ -53,6 +53,7 @@ describe('upload-forms', () => {
         expect(form.icon).to.equal('example');
         expect(form.xml2sms).to.equal('hello world');
         expect(form.subject_key).to.equal('some.translation.key');
+        expect(form.hidden_fields[0]).to.equal('hidden');
       });
   });
 


### PR DESCRIPTION
The hidden_fields propery is supported and should not WARN.

medic/medic-conf#377

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
