### PR TITLE
Fix typo contact actions and schema validations (#358)

### DIFF
--- a/src/lib/validate-declarative-schema.js
+++ b/src/lib/validate-declarative-schema.js
@@ -122,8 +122,8 @@ const TaskSchema = joi.array().items(
       .error(taskError('"priority" should be an object with optional fields "level" and "label" or a function which returns the same')),
     actions: joi.array().items(
       joi.object({
-        type: joi.string().valid('report', 'contacts').optional(),
-        form: joi.string().min(1).required(),
+        type: joi.string().valid('report', 'contact').optional(),
+        form: joi.string().min(1).optional(),
         label: joi.string().min(1).optional(),
         modifyContent: joi.function().optional()
           .error(taskError('"actions.modifyContent" should be "function (content, contact, report)')),

--- a/src/lib/validate-declarative-schema.js
+++ b/src/lib/validate-declarative-schema.js
@@ -123,7 +123,7 @@ const TaskSchema = joi.array().items(
     actions: joi.array().items(
       joi.object({
         type: joi.string().valid('report', 'contact').optional(),
-        form: joi.string().min(1).optional(),
+        form: joi.string().min(1).required(),
         label: joi.string().min(1).optional(),
         modifyContent: joi.function().optional()
           .error(taskError('"actions.modifyContent" should be "function (content, contact, report)')),

--- a/src/lib/validate-declarative-schema.js
+++ b/src/lib/validate-declarative-schema.js
@@ -123,7 +123,7 @@ const TaskSchema = joi.array().items(
     actions: joi.array().items(
       joi.object({
         type: joi.string().valid('report', 'contact').optional(),
-        form: joi.string().min(1).required(),
+        form: joi.alternatives().conditional('type', { is: 'contact', then: joi.forbidden(), otherwise: joi.string().min(1).required() }),
         label: joi.string().min(1).optional(),
         modifyContent: joi.function().optional()
           .error(taskError('"actions.modifyContent" should be "function (content, contact, report)')),

--- a/src/nools/task-emitter.js
+++ b/src/nools/task-emitter.js
@@ -154,15 +154,12 @@ function emitTasks(taskDefinition, Utils, Task, emit, c, r) {
       def.modifyContent(content, c, r);
     }
 
-    var action = {
+    return {
       type: def.type || 'report',
+      form: def.form,
       label: def.label || 'Follow up',
       content: content,
     };
-    if (def.form) {
-      action.form = def.form;
-    }
-    return action;
   }
 }
 

--- a/src/nools/task-emitter.js
+++ b/src/nools/task-emitter.js
@@ -154,12 +154,15 @@ function emitTasks(taskDefinition, Utils, Task, emit, c, r) {
       def.modifyContent(content, c, r);
     }
 
-    return {
-      type: 'report',
-      form: def.form,
+    var action = {
+      type: def.type || 'report',
       label: def.label || 'Follow up',
       content: content,
     };
+    if (def.form) {
+      action.form = def.form;
+    }
+    return action;
   }
 }
 

--- a/test/lib/validate-declarative-schema.spec.js
+++ b/test/lib/validate-declarative-schema.spec.js
@@ -4,14 +4,79 @@ const rewire = require('rewire');
 
 const validateDeclarativeSchema = rewire('../../src/lib/validate-declarative-schema');
 
+const buildContactAction = typeName => ({
+  name: 'patient_create',
+  icon: 'icon-person',
+  title: 'patient_create',
+  appliesTo: 'contacts',
+  appliesToType: ['clinic'],
+  appliesIf: () => true,
+  resolvedIf: () => false,
+  actions: [
+    {
+      type: typeName || 'contact',
+      form: 'home_visit',
+      modifyContent: function (content, contact) {
+        content.type = 'person';
+        content.parent_id = contact && contact.contact._id;
+      }
+    }
+  ],
+  events: [
+    {
+      id: 'creation-follow-up',
+      start: 3, end: 7,
+      dueDate: function (event, contact) {
+        return contact.contact.reported_date;
+      }
+    }
+  ]
+});
+
 describe('validate-declarative-schema', () => {
   describe('validate', () => {
     const validate = (...args) => validateDeclarativeSchema.__get__('validate')('desc', ...args);
+    const TaskSchema = validateDeclarativeSchema.__get__('TaskSchema');
 
     it('array.unique', () => {
       const schema = joi.array().items(joi.object()).unique('name');
       const actual = validate([{ name: 'a' }, { name: 'a' }], schema);
       expect(actual).to.deep.eq(['desc[1] contains duplicate value for the "name" field: "a"']);
+    });
+
+    it('actions[].type = report no errors', () => {
+      const actual = validate([buildContactAction('report')], TaskSchema);
+      expect(actual).to.be.empty;
+    });
+
+    it('actions[].type = contact no errors', () => {
+      const actual = validate([buildContactAction()], TaskSchema);
+      expect(actual).to.be.empty;
+    });
+
+    it('actions[].type = wrong-type-name then error', () => {
+      const actual = validate([buildContactAction('wrong-type-name')], TaskSchema);
+      expect(actual).to.deep.eq([
+        '"[0].actions[0].type" must be one of [report, contact]. Value is: "wrong-type-name"'
+      ]);
+    });
+
+    it('a[0].events or [0].actions empty then required error', () => {
+      const actual = validate([
+        {
+          name: 'patient_create',
+          icon: 'icon-person',
+          title: 'patient_create',
+          appliesTo: 'contacts',
+          appliesToType: ['clinic'],
+          appliesIf: () => true,
+          resolvedIf: () => false
+        }
+      ], TaskSchema);
+      expect(actual).to.deep.eq([
+        '"[0].events" is required',
+        '"[0].actions" is required'
+      ]);
     });
 
     it('array.unique internal', () => {


### PR DESCRIPTION
# Description

Fix validations and task emitter that case actions with type "contact" don't follow the schema as expected, failing when when it tries to push the configurations.

medic/medic-conf#358

**In progress**:

- [x] Rebase (specially to move the build out of Travis)
- [x] Improve validations
- [x] Add tests
- [x] Check documentation (ensure schema is well documented) → [schema documentation](https://docs.communityhealthtoolkit.org/apps/reference/tasks/) is fine, no need for updates

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
