### PR TITLE
Consistent contact type in contact summary and targets.

### DIFF
--- a/src/contact-summary/contact-summary-emitter.js
+++ b/src/contact-summary/contact-summary-emitter.js
@@ -3,7 +3,7 @@ function emitter(contactSummary, contact, reports) {
   var context = contactSummary.context || {};
   var cards = contactSummary.cards || [];
 
-  var contactType = contact && (contact.contact_type || contact.type);
+  var contactType = contact && (contact.type === 'contact' ? contact.contact_type : contact.type);
 
   var result = {
     cards: [],
@@ -31,7 +31,7 @@ function emitter(contactSummary, contact, reports) {
     if (appliesToType.includes('report') && appliesToType.length > 1) {
       throw new Error("You cannot set appliesToType to an array which includes the type 'report' and another type.");
     }
-    
+
     if (appliesToType.includes('report')) {
       for (idx1=0; idx1<reports.length; ++idx1) {
         r = reports[idx1];
@@ -66,7 +66,7 @@ function convertToArray(appliesToType) {
   if (!appliesToType) {
     return [];
   }
-  return Array.isArray(appliesToType) ? appliesToType : [appliesToType];  
+  return Array.isArray(appliesToType) ? appliesToType : [appliesToType];
 }
 
 function isReportValid(report) {

--- a/src/nools/target-emitter.js
+++ b/src/nools/target-emitter.js
@@ -25,7 +25,7 @@ function determineDate(targetConfig, Utils, c, r) {
   if (typeof targetConfig.date === 'function') {
     return targetConfig.date(c, r);
   }
-  
+
   if (targetConfig.date === undefined || targetConfig.date === 'now') {
     return Utils.now().getTime();
   }
@@ -33,7 +33,7 @@ function determineDate(targetConfig, Utils, c, r) {
   if (targetConfig.date === 'reported') {
     return r ? r.reported_date : c.contact.reported_date;
   }
-  
+
   throw new Error('Unrecognised value for target.date: ' + targetConfig.date);
 }
 
@@ -57,7 +57,7 @@ function determineInstanceIds(targetConfig, c, r) {
 function emitTargetFor(targetConfig, Target, Utils, emit, c, r) {
   var isEmittingForReport = !!r;
   if (!c.contact) return;
-  var contactType = c.contact.contact_type || c.contact.type;
+  var contactType = c.contact.type === 'contact' ? c.contact.contact_type : c.contact.type;
   var appliesToKey = isEmittingForReport ? r.form : contactType;
   if (targetConfig.appliesToType && targetConfig.appliesToType.indexOf(appliesToKey) < 0) return;
   if (targetConfig.appliesIf && !targetConfig.appliesIf (c, r)) return;

--- a/test/contact-summary/contact-summary-emitter.spec.js
+++ b/test/contact-summary/contact-summary-emitter.spec.js
@@ -101,6 +101,37 @@ describe('contact-summary-emitter', function() {
         expect(e.message).to.include('You cannot set appliesToType');
       }
     });
+
+    it('should prioritize contact.type over contact.contact_type', () => {
+      const appliesIf = sinon.stub().returns(false);
+      const appliesIfPatient = sinon.stub().returns(false);
+      const appliesIfAll = sinon.stub().returns(false);
+      const cards = [
+        { appliesIf: appliesIf, appliesToType: ['person'], fields: [], },
+        { appliesIf: appliesIfPatient, appliesToType: ['patient'], fields: [], },
+        { appliesIf: appliesIfAll, appliesToType: ['patient', 'person'], fields: [], },
+      ];
+
+      const report = { report: true };
+      emitter({ cards }, { type: 'person', contact_type: 'patient' }, [report]);
+      assert.equal(appliesIf.callCount, 1);
+      assert.equal(appliesIfPatient.callCount, 0);
+      assert.equal(appliesIfAll.callCount, 1);
+
+      sinon.resetHistory();
+
+      emitter({ cards }, { type: 'contact', contact_type: 'patient' }, [report]);
+      assert.equal(appliesIf.callCount, 0);
+      assert.equal(appliesIfPatient.callCount, 1);
+      assert.equal(appliesIfAll.callCount, 1);
+
+      sinon.resetHistory();
+
+      emitter({ cards }, { type: 'contact', contact_type: 'neither' }, [report]);
+      assert.equal(appliesIf.callCount, 0);
+      assert.equal(appliesIfPatient.callCount, 0);
+      assert.equal(appliesIfAll.callCount, 0);
+    });
   });
 
   describe('fields', () => {
@@ -167,6 +198,37 @@ describe('contact-summary-emitter', function() {
       const result = emitter({ fields }, {}, [report]);
 
       expect(result.fields).to.deep.eq(fields);
+    });
+
+    it('should prioritize contact.type over contact.contact_type', () => {
+      const appliesIf = sinon.stub().returns(false);
+      const appliesIfPatient = sinon.stub().returns(false);
+      const appliesIfAll = sinon.stub().returns(false);
+      const fields = [
+        { appliesIf: appliesIf, appliesToType: ['person'], },
+        { appliesIf: appliesIfPatient, appliesToType: ['patient'], },
+        { appliesIf: appliesIfAll, appliesToType: ['patient', 'person'], },
+      ];
+
+      const report = { report: true };
+      emitter({ fields }, { type: 'person', contact_type: 'patient' }, [report]);
+      assert.equal(appliesIf.callCount, 1);
+      assert.equal(appliesIfPatient.callCount, 0);
+      assert.equal(appliesIfAll.callCount, 1);
+
+      sinon.resetHistory();
+
+      emitter({ fields }, { type: 'contact', contact_type: 'patient' }, [report]);
+      assert.equal(appliesIf.callCount, 0);
+      assert.equal(appliesIfPatient.callCount, 1);
+      assert.equal(appliesIfAll.callCount, 1);
+
+      sinon.resetHistory();
+
+      emitter({ fields }, { type: 'contact', contact_type: 'neither' }, [report]);
+      assert.equal(appliesIf.callCount, 0);
+      assert.equal(appliesIfPatient.callCount, 0);
+      assert.equal(appliesIfAll.callCount, 0);
     });
   });
 

--- a/test/nools/target-emitter.spec.js
+++ b/test/nools/target-emitter.spec.js
@@ -531,5 +531,67 @@ describe('target emitter', () => {
         { _type:'_complete', _id: true },
       ]);
     });
+
+    it('hardcoded contact type with a contact_type property, target matching type', () => {
+      const target = aPersonBasedTarget();
+      target.appliesToType = ['person'];
+
+      const config = {
+        c: personWithReports(aReport()),
+        targets: [ target ],
+        tasks: [],
+      };
+      config.c.contact.contact_type = 'something';
+
+      // when
+      const emitted = runNoolsLib(config).emitted;
+
+      // then
+      assert.deepEqual(emitted, [
+        { _id: 'c-3~pT-1', _type:'target', date: TEST_DATE },
+        { _type:'_complete', _id: true },
+      ]);
+    });
+
+    it('hardcoded contact type with a contact_type property, target matching contact_type', () => {
+      const target = aPersonBasedTarget();
+      target.appliesToType = ['something'];
+
+      const config = {
+        c: personWithReports(aReport()),
+        targets: [ target ],
+        tasks: [],
+      };
+      config.c.contact.contact_type = 'something';
+
+      // when
+      const emitted = runNoolsLib(config).emitted;
+
+      // then
+      assert.deepEqual(emitted, [
+        { _type:'_complete', _id: true },
+      ]);
+    });
+
+    it('hardcoded contact type with a contact_type property, target matching type and contact_type', () => {
+      const target = aPersonBasedTarget();
+      target.appliesToType = ['person', 'something'];
+
+      const config = {
+        c: personWithReports(aReport()),
+        targets: [ target ],
+        tasks: [],
+      };
+      config.c.contact.contact_type = 'something';
+
+      // when
+      const emitted = runNoolsLib(config).emitted;
+
+      // then
+      assert.deepEqual(emitted, [
+        { _id: 'c-3~pT-1', _type:'target', date: TEST_DATE },
+        { _type:'_complete', _id: true },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
# Description

Only use `contact_type` field when `type` field value is `contact`. 
Fixes contact-summary fields and cards not being displayed correctly for contacts that use hardcoded types and have a `contact_property` field. 
Fixes these contacts not being counted towards target goals. 

medic/medic-conf#382

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
