### PR TITLE
Add default "resolvedIf" function for tasks

### DIFF
--- a/src/lib/validate-declarative-schema.js
+++ b/src/lib/validate-declarative-schema.js
@@ -104,7 +104,7 @@ const TaskSchema = joi.array().items(
     contactLabel:
       joi.alternatives().try( joi.string().min(1), joi.function() ).optional()
       .error(taskError('"contactLabel" should either be a non-empty string or function(contact, report)')),
-    resolvedIf: joi.function().required()
+    resolvedIf: joi.function().optional()
       .error(taskError('"resolvedIf" should be of type function(contact, report)')),
     events: joi.alternatives().conditional('events', {
       is: joi.array().length(1),

--- a/src/lib/validate-declarative-schema.js
+++ b/src/lib/validate-declarative-schema.js
@@ -104,12 +104,19 @@ const TaskSchema = joi.array().items(
     contactLabel:
       joi.alternatives().try( joi.string().min(1), joi.function() ).optional()
       .error(taskError('"contactLabel" should either be a non-empty string or function(contact, report)')),
-    resolvedIf: joi.alternatives().conditional('actions', {
-      is: joi.array().items(joi.object({ type: 'contact' }).unknown()),
-      then: joi.function().required(),
-      otherwise: joi.function().optional()
-    })
-      .error(taskError('"resolvedIf" should be of type function(contact, report) if there is no report action')),
+    resolvedIf: joi
+      .alternatives()
+      .conditional('actions', {
+        is: joi.array().has(joi.object({ type: 'report' }).unknown()),
+        then: joi.function().optional(),
+        otherwise: joi.function().required()
+      })
+      .error(
+        taskError(
+          'ERROR: Schema error in actions array: Actions with property "type" which value is different than "report", ' +
+          'should define property "resolvedIf" as: function(contact, report) { ... }.'
+        )
+      ),
     events: joi.alternatives().conditional('events', {
       is: joi.array().length(1),
       then: joi.array().items(EventSchema('optional')).min(1).required(),

--- a/src/lib/validate-declarative-schema.js
+++ b/src/lib/validate-declarative-schema.js
@@ -104,8 +104,12 @@ const TaskSchema = joi.array().items(
     contactLabel:
       joi.alternatives().try( joi.string().min(1), joi.function() ).optional()
       .error(taskError('"contactLabel" should either be a non-empty string or function(contact, report)')),
-    resolvedIf: joi.function().optional()
-      .error(taskError('"resolvedIf" should be of type function(contact, report)')),
+    resolvedIf: joi.alternatives().conditional('actions', {
+      is: joi.array().items(joi.object({ type: 'contact' }).unknown()),
+      then: joi.function().required(),
+      otherwise: joi.function().optional()
+    })
+      .error(taskError('"resolvedIf" should be of type function(contact, report) if there is no report action')),
     events: joi.alternatives().conditional('events', {
       is: joi.array().length(1),
       then: joi.array().items(EventSchema('optional')).min(1).required(),

--- a/src/nools/definition-preparation.js
+++ b/src/nools/definition-preparation.js
@@ -10,7 +10,15 @@ function prepare(definition, defaultResolvedIf, Utils) {
   targetContext.definition = deepCopy(definition);
   if (defaultResolvedIf) {
     targetContext.defaultResolvedIf = function (contact, report, event, dueDate, resolvingForm) {
-      return defaultResolvedIf(contact, report, event, dueDate, resolvingForm || definition.actions[0].form, Utils);
+      if(!resolvingForm) {
+        var reportAction = definition.actions.find(function (action) { return action.type === 'report'; });
+        if(!reportAction) {
+          throw new Error('Could not find the default resolving form. You need to provide the resolvingForm when using "this.defaultResolvedIf(contact, report, event, dueDate, resolvingForm)"'
+            + 'if you don\'t have any action with "type: \'report\'".');
+        }
+        return defaultResolvedIf(contact, report, event, dueDate, reportAction.form, Utils);
+      }
+      return defaultResolvedIf(contact, report, event, dueDate, resolvingForm, Utils);
     };
 
   }

--- a/src/nools/definition-preparation.js
+++ b/src/nools/definition-preparation.js
@@ -4,24 +4,10 @@ Definition-preparation.js binds a value for `this` in all the functions within a
 This fascilitates simple data sharing between functions, and allows function logic to reference the definition itself.
 */
 
-function prepare(definition, defaultResolvedIf, Utils) {
+function prepare(definition) {
   var targetContext = {};
   bindAllFunctionsToContext(definition, targetContext);
   targetContext.definition = deepCopy(definition);
-  if (defaultResolvedIf) {
-    targetContext.defaultResolvedIf = function (contact, report, event, dueDate, resolvingForm) {
-      if(!resolvingForm) {
-        var reportAction = definition.actions.find(function (action) { return action.type === 'report'; });
-        if(!reportAction) {
-          throw new Error('Could not find the default resolving form. You need to provide the resolvingForm when using "this.defaultResolvedIf(contact, report, event, dueDate, resolvingForm)"'
-            + 'if you don\'t have any action with "type: \'report\'".');
-        }
-        return defaultResolvedIf(contact, report, event, dueDate, reportAction.form, Utils);
-      }
-      return defaultResolvedIf(contact, report, event, dueDate, resolvingForm, Utils);
-    };
-
-  }
 }
 
 function bindAllFunctionsToContext(obj, context) {

--- a/src/nools/definition-preparation.js
+++ b/src/nools/definition-preparation.js
@@ -4,10 +4,16 @@ Definition-preparation.js binds a value for `this` in all the functions within a
 This fascilitates simple data sharing between functions, and allows function logic to reference the definition itself.
 */
 
-function prepare(definition) {
+function prepare(definition, defaultResolvedIf, Utils) {
   var targetContext = {};
   bindAllFunctionsToContext(definition, targetContext);
   targetContext.definition = deepCopy(definition);
+  if (defaultResolvedIf) {
+    targetContext.defaultResolvedIf = function (contact, report, event, dueDate, resolvingForm) {
+      return defaultResolvedIf(contact, report, event, dueDate, resolvingForm || definition.actions[0].form, Utils);
+    };
+
+  }
 }
 
 function bindAllFunctionsToContext(obj, context) {

--- a/src/nools/task-defaults.js
+++ b/src/nools/task-defaults.js
@@ -2,19 +2,25 @@
 function taskDefaults(Utils) {
   return {
     defaultResolvedIf: function (contact, report, event, dueDate) {
+      var start;
+      var end;
       var resolvingForm = getDefaultResolvingForm(this.definition);
-      if (typeof resolvingForm !== 'string') {
+      if (!resolvingForm) {
         throw new Error('Could not find the default resolving form!');
       }
-      var start = 0;
+      start = 0;
       if (report) {//Report based task
         //Getting the latest date between start of the task's window and just after the report's reported date.
         start = Math.max(Utils.addDate(dueDate, -event.start).getTime(), report.reported_date + 1);
       }
       else {
-        start = Utils.addDate(dueDate, -event.start).getTime();
+        start = Utils
+        .addDate(dueDate, -event.start)
+        .getTime();
       }
-      var end = Utils.addDate(dueDate, event.end + 1).getTime();
+      end = Utils
+      .addDate(dueDate, event.end + 1)
+      .getTime();
       return Utils.isFormSubmittedInWindow(
         contact.reports,
         resolvingForm,
@@ -26,12 +32,17 @@ function taskDefaults(Utils) {
 }
 
 function getDefaultResolvingForm(taskDefinition) {
-  var resolvingAction = taskDefinition && taskDefinition.actions &&
-    taskDefinition.actions.find(
-      function (action) {
-        return action.type === 'report' || typeof action.type === 'undefined';
-      }
-    );
+  var resolvingAction;
+
+  if (!taskDefinition || !taskDefinition.actions) {
+    return;
+  }
+
+  resolvingAction = taskDefinition.actions.find(
+    function (action) {
+      return !action.type || action.type === 'report';
+    }
+  );
   return resolvingAction && resolvingAction.form;
 }
 

--- a/src/nools/task-defaults.js
+++ b/src/nools/task-defaults.js
@@ -1,0 +1,38 @@
+// File defining task defaults
+function taskDefaults(Utils) {
+  return {
+    defaultResolvedIf: function (contact, report, event, dueDate) {
+      var resolvingForm = getDefaultResolvingForm(this.definition);
+      if (typeof resolvingForm !== 'string') {
+        throw new Error('Could not find the default resolving form!');
+      }
+      var start = 0;
+      if (report) {//Report based task
+        //Getting the latest date between start of the task's window and just after the report's reported date.
+        start = Math.max(Utils.addDate(dueDate, -event.start).getTime(), report.reported_date + 1);
+      }
+      else {
+        start = Utils.addDate(dueDate, -event.start).getTime();
+      }
+      var end = Utils.addDate(dueDate, event.end + 1).getTime();
+      return Utils.isFormSubmittedInWindow(
+        contact.reports,
+        resolvingForm,
+        start,
+        end
+      );
+    }
+  };
+}
+
+function getDefaultResolvingForm(taskDefinition) {
+  var resolvingAction = taskDefinition && taskDefinition.actions &&
+    taskDefinition.actions.find(
+      function (action) {
+        return action.type === 'report' || typeof action.type === 'undefined';
+      }
+    );
+  return resolvingAction && resolvingAction.form;
+}
+
+module.exports = taskDefaults;

--- a/src/nools/task-defaults.js
+++ b/src/nools/task-defaults.js
@@ -18,12 +18,12 @@ module.exports = {
     }
     else {
       start = _utils
-      .addDate(dueDate, -event.start)
-      .getTime();
+        .addDate(dueDate, -event.start)
+        .getTime();
     }
     end = _utils
-    .addDate(dueDate, event.end + 1)
-    .getTime();
+      .addDate(dueDate, event.end + 1)
+      .getTime();
     return _utils.isFormSubmittedInWindow(
       contact.reports,
       resolvingForm,
@@ -34,16 +34,16 @@ module.exports = {
 };
 
 function getDefaultResolvingForm(taskDefinition) {
-var resolvingAction;
+  var resolvingAction;
 
-if (!taskDefinition || !taskDefinition.actions) {
-  return;
-}
-
-resolvingAction = taskDefinition.actions.find(
-  function (action) {
-    return !action.type || action.type === 'report';
+  if (!taskDefinition || !taskDefinition.actions) {
+    return;
   }
-);
-return resolvingAction && resolvingAction.form;
+
+  resolvingAction = taskDefinition.actions.find(
+    function (action) {
+      return !action.type || action.type === 'report';
+    }
+  );
+  return resolvingAction && resolvingAction.form;
 }

--- a/src/nools/task-defaults.js
+++ b/src/nools/task-defaults.js
@@ -1,49 +1,49 @@
 // File defining task defaults
-function taskDefaults(Utils) {
-  return {
-    defaultResolvedIf: function (contact, report, event, dueDate) {
-      var start;
-      var end;
-      var resolvingForm = getDefaultResolvingForm(this.definition);
-      if (!resolvingForm) {
-        throw new Error('Could not find the default resolving form!');
-      }
-      start = 0;
-      if (report) {//Report based task
-        //Getting the latest date between start of the task's window and just after the report's reported date.
-        start = Math.max(Utils.addDate(dueDate, -event.start).getTime(), report.reported_date + 1);
-      }
-      else {
-        start = Utils
-        .addDate(dueDate, -event.start)
-        .getTime();
-      }
-      end = Utils
-      .addDate(dueDate, event.end + 1)
-      .getTime();
-      return Utils.isFormSubmittedInWindow(
-        contact.reports,
-        resolvingForm,
-        start,
-        end
-      );
+module.exports = {
+  defaultResolvedIf: function (contact, report, event, dueDate, _utils) {
+    //Utils is made available to the global scope when compiling nools in the CHT core
+    if (!_utils) {
+      _utils = Utils;
     }
-  };
-}
+    var start;
+    var end;
+    var resolvingForm = getDefaultResolvingForm(this.definition);
+    if (!resolvingForm) {
+      throw new Error('Could not find the default resolving form!');
+    }
+    start = 0;
+    if (report) {//Report based task
+      //Getting the latest date between start of the task's window and just after the report's reported date.
+      start = Math.max(_utils.addDate(dueDate, -event.start).getTime(), report.reported_date + 1);
+    }
+    else {
+      start = _utils
+      .addDate(dueDate, -event.start)
+      .getTime();
+    }
+    end = _utils
+    .addDate(dueDate, event.end + 1)
+    .getTime();
+    return _utils.isFormSubmittedInWindow(
+      contact.reports,
+      resolvingForm,
+      start,
+      end
+    );
+  }
+};
 
 function getDefaultResolvingForm(taskDefinition) {
-  var resolvingAction;
+var resolvingAction;
 
-  if (!taskDefinition || !taskDefinition.actions) {
-    return;
-  }
-
-  resolvingAction = taskDefinition.actions.find(
-    function (action) {
-      return !action.type || action.type === 'report';
-    }
-  );
-  return resolvingAction && resolvingAction.form;
+if (!taskDefinition || !taskDefinition.actions) {
+  return;
 }
 
-module.exports = taskDefaults;
+resolvingAction = taskDefinition.actions.find(
+  function (action) {
+    return !action.type || action.type === 'report';
+  }
+);
+return resolvingAction && resolvingAction.form;
+}

--- a/src/nools/task-emitter.js
+++ b/src/nools/task-emitter.js
@@ -124,8 +124,8 @@ function emitTasks(taskDefinition, Utils, Task, emit, c, r) {
         readyStart: event.start || 0,
         readyEnd: event.end || 0,
         title: taskDefinition.title,
-        resolved: taskDefinition.resolvedIf(c, r, event, dueDate, taskDefinition, scheduledTaskIdx),
-        actions: taskDefinition.actions.map(initActions),
+        resolved: taskDefinition.resolvedIf(c, r, event, dueDate, scheduledTaskIdx),
+        actions: initActions(taskDefinition.actions, event),
       };
 
       if (scheduledTaskIdx !== undefined) {

--- a/src/nools/task-emitter.js
+++ b/src/nools/task-emitter.js
@@ -6,9 +6,11 @@ function taskEmitter(taskDefinitions, c, Utils, Task, emit) {
 
   var taskDefinition, r;
   for (var idx1 = 0; idx1 < taskDefinitions.length; ++idx1) {
-    taskDefinition = Object.assign({}, taskDefinitions[idx1], taskDefaults(Utils));
+    taskDefinition = Object.assign({}, taskDefinitions[idx1], taskDefaults);
     if (typeof taskDefinition.resolvedIf !== 'function') {
-      taskDefinition.resolvedIf = taskDefinition.defaultResolvedIf;
+      taskDefinition.resolvedIf = function (contact, report, event, dueDate) {
+        return taskDefinition.defaultResolvedIf(contact, report, event, dueDate, Utils);
+      };
     }
     prepareDefinition(taskDefinition);
 

--- a/src/nools/task-emitter.js
+++ b/src/nools/task-emitter.js
@@ -6,10 +6,10 @@ function taskEmitter(taskDefinitions, c, Utils, Task, emit) {
 
   var taskDefinition, r;
   for (var idx1 = 0; idx1 < taskDefinitions.length; ++idx1) {
-    taskDefinition = Object.assign({}, taskDefinitions[idx1],  taskDefaults(Utils));
+    taskDefinition = Object.assign({}, taskDefinitions[idx1], taskDefaults(Utils));
     if (typeof taskDefinition.resolvedIf !== 'function') {
       taskDefinition.resolvedIf = taskDefinition.defaultResolvedIf;
-  }
+    }
     prepareDefinition(taskDefinition);
 
     switch (taskDefinition.appliesTo) {

--- a/src/nools/task-emitter.js
+++ b/src/nools/task-emitter.js
@@ -127,7 +127,8 @@ function emitTasks(taskDefinition, Utils, Task, emit, c, r) {
         task.resolved = taskDefinition.resolvedIf(c, r, event, dueDate, scheduledTaskIdx);
       }
       else {
-        task.resolved = defaultResolvedIf(c, r, event, dueDate, taskDefinition.actions[0].form, Utils);
+        var resolvingForm = taskDefinition.actions.find(function (action) { return action.type === 'report'; }).form;
+        task.resolved = defaultResolvedIf(c, r, event, dueDate, resolvingForm, Utils);
       }
 
       if (scheduledTaskIdx !== undefined) {

--- a/test/lib/validate-declarative-schema.spec.js
+++ b/test/lib/validate-declarative-schema.spec.js
@@ -156,7 +156,11 @@ describe('validate-declarative-schema', () => {
       let aTask = buildTaskWithAction();
       aTask.actions = actionsCollection.oneActionReportType;
       delete aTask.resolvedIf;
+
+      // when
       const actual = validate([aTask], TaskSchema);
+
+      // then
       expect(actual).to.be.empty;
     });
 
@@ -165,7 +169,11 @@ describe('validate-declarative-schema', () => {
       let aTask = buildTaskWithAction();
       aTask.actions = actionsCollection.twoActionsOneReportType;
       delete aTask.resolvedIf;
+
+      // when
       const actual = validate([aTask], TaskSchema);
+
+      // then
       expect(actual).to.be.empty;
     });
 
@@ -174,7 +182,11 @@ describe('validate-declarative-schema', () => {
       let aTask = buildTaskWithAction();
       aTask.actions = actionsCollection.oneActionReportUndefined;
       delete aTask.resolvedIf;
+
+      // when
       const actual = validate([aTask], TaskSchema);
+
+      // then
       expect(actual).to.be.empty;
     });
 
@@ -183,7 +195,11 @@ describe('validate-declarative-schema', () => {
       let aTask = buildTaskWithAction();
       aTask.actions = actionsCollection.oneActionContactType;
       delete aTask.resolvedIf;
+
+      // when
       const actual = validate([aTask], TaskSchema);
+
+      // then
       expect(actual).to.deep.eq(
         ['Invalid schema at tasks[0].resolvedIf\nERROR: Schema error in actions array: Actions with property "type" which value is different than "report", ' + 
          'should define property "resolvedIf" as: function(contact, report) { ... }.\nCurrent value of tasks[0].resolvedIf is undefined\n']);

--- a/test/nools/mocks.js
+++ b/test/nools/mocks.js
@@ -27,7 +27,7 @@ function aTask(type) {
     appliesTo: type,
     name: `task-${idCounter}`,
     title: [ { locale:'en', content:`Task ${idCounter}` } ],
-    actions: [ {form:'example-form' } ],
+    actions: [{ form: 'example-form' }],
     events: [ {
       id: `task`,
       days:0, start:0, end:1,

--- a/test/nools/mocks.js
+++ b/test/nools/mocks.js
@@ -27,7 +27,7 @@ function aTask(type) {
     appliesTo: type,
     name: `task-${idCounter}`,
     title: [ { locale:'en', content:`Task ${idCounter}` } ],
-    actions: [ {type: 'report', form:'example-form' } ],
+    actions: [ {form:'example-form' } ],
     events: [ {
       id: `task`,
       days:0, start:0, end:1,

--- a/test/nools/mocks.js
+++ b/test/nools/mocks.js
@@ -27,7 +27,7 @@ function aTask(type) {
     appliesTo: type,
     name: `task-${idCounter}`,
     title: [ { locale:'en', content:`Task ${idCounter}` } ],
-    actions: [ { form:'example-form' } ],
+    actions: [ {type: 'report', form:'example-form' } ],
     events: [ {
       id: `task`,
       days:0, start:0, end:1,

--- a/test/nools/task-emitter.spec.js
+++ b/test/nools/task-emitter.spec.js
@@ -22,11 +22,11 @@ const utilsMock = {
   now: sinon.stub().returns(new Date(TEST_DATE)),
   isTimely: sinon.stub().returns(true),
   isFormSubmittedInWindow: sinon.stub().returns(true),
-  addDate: function (date, days) {
-    const d = new Date(date.getTime());
-    d.setDate(d.getDate() + days);
-    d.setHours(0, 0, 0, 0);
-    return d;
+  addDate: (date, days) => {
+    const newDate = new Date(date.getTime());
+    newDate.setDate(newDate.getDate() + days);
+    newDate.setHours(0, 0, 0, 0);
+    return newDate;
   }
 };
 const { assert, expect } = chai;
@@ -671,7 +671,7 @@ describe('task-emitter', () => {
     });
 
     describe('defaultResolvedIf', () => {
-      it('given task definition without resolved_date, resolvedIf defaults to default and resolves the task', () => {
+      it('given task definition without resolvedIf, it defaults to defaultResolvedIf', () => {
         sinon.useFakeTimers();
 
         // given
@@ -682,10 +682,11 @@ describe('task-emitter', () => {
           utilsMock
         };
         delete config.tasks[0].resolvedIf;
+
         // when
         const { emitted } = runNoolsLib(config);
-        //then
 
+        // then
         expect(utilsMock.isFormSubmittedInWindow.callCount).to.equal(1);
         expect(emitted[0].resolved).to.be.true;
       });
@@ -700,39 +701,14 @@ describe('task-emitter', () => {
         };
 
         config.tasks[0].resolvedIf = function (contact, report, event, dueDate) {
-          return this.definition.defaultResolvedIf(contact, report, event, dueDate) && false;//never resolved
+          return this.definition.defaultResolvedIf(contact, report, event, dueDate);
         };
 
         // when
         const { emitted } = runNoolsLib(config);
 
         // then
-        expect(emitted[0]).to.nested.include({
-          'actions[0].content.source_id': 'r-1',
-          resolved: false,//not resolved
-        });
-
-        //given
-        const resolvingReport = aReport();
-        resolvingReport.form = 'example-form';
-        resolvingReport.reported_date = TEST_DATE + 1;
-
-        //when
-        config.c.reports.push(resolvingReport);
-        let emittedAgain = runNoolsLib(config).emitted;
-
-        //then
-        expect(emittedAgain[0].resolved).to.be.false;//still not resolved
-
-        //when
-        config.tasks[0].resolvedIf = function (contact, report, event, dueDate) {
-          return this.definition.defaultResolvedIf(contact, report, event, dueDate);
-        };
-        emittedAgain = runNoolsLib(config).emitted;
-
-        //then
-        expect(emittedAgain[0].resolved).to.be.true;//resolved
-
+        expect(emitted[0].resolved).to.be.true;
       });
     });
 

--- a/test/nools/task-emitter.spec.js
+++ b/test/nools/task-emitter.spec.js
@@ -701,7 +701,7 @@ describe('task-emitter', () => {
         };
 
         config.tasks[0].resolvedIf = function (contact, report, event, dueDate) {
-          return this.definition.defaultResolvedIf(contact, report, event, dueDate);
+          return this.definition.defaultResolvedIf(contact, report, event, dueDate, utilsMock);
         };
 
         // when

--- a/test/nools/task-emitter.spec.js
+++ b/test/nools/task-emitter.spec.js
@@ -18,6 +18,17 @@ const {
   placeWithoutReports,
 } = require('./mocks');
 
+const utilsMock = {
+  now: sinon.stub().returns(new Date(TEST_DATE)),
+  isTimely: sinon.stub().returns(true),
+  isFormSubmittedInWindow: sinon.stub().returns(true),
+  addDate: function (date, days) {
+    const d = new Date(date.getTime());
+    d.setDate(d.getDate() + days);
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }
+};
 const { assert, expect } = chai;
 chai.use(require('chai-shallow-deep-equal'));
 
@@ -288,136 +299,7 @@ describe('task-emitter', () => {
         });
       });
 
-      it('resolvedIf is not required', () => {
-        // given
-        const config = {
-          c: personWithReports(aReport()),
-          targets: [],
-          tasks: [aReportBasedTask()],
-        };
-        delete config.tasks[0].resolvedIf;
-
-        // when
-        const { emitted } = runNoolsLib(config);
-
-        // then
-        expect(emitted[0]).to.nested.include({
-          'actions[0].content.source_id': 'r-1',
-          resolved: false,
-        });
-      });
-
-      it('this.defaultResolvedIf can be passed to resolvedIf', () => {
-        // given
-        const config = {
-          c: personWithReports(aReport()),
-          targets: [],
-          tasks: [aReportBasedTask()],
-        };
-
-        config.tasks[0].resolvedIf = this.defaultResolvedIf;
-
-        // when
-        const { emitted } = runNoolsLib(config);
-
-        // then
-        expect(emitted[0]).to.nested.include({
-          'actions[0].content.source_id': 'r-1',
-          resolved: false,
-        });
-
-        //given
-        const resolvingReport = aReport();
-        resolvingReport.form = 'example-form';
-        resolvingReport.reported_date = TEST_DATE + 1;
-
-        //when
-        config.c.reports.push(resolvingReport);
-        const emittedAgain = runNoolsLib(config).emitted;
-
-        //then
-        expect(emittedAgain[0].resolved).to.be.true;
-      });
-
-      it('this.defaultResolvedIf can be used inside resolvedIf', () => {
-        // given
-        const config = {
-          c: personWithReports(aReport()),
-          targets: [],
-          tasks: [aReportBasedTask()],
-        };
-
-        config.tasks[0].resolvedIf = function (contact, report, event, dueDate) {
-          return this.defaultResolvedIf(contact, report, event, dueDate) && false;//never resolved
-        };
-
-        // when
-        const { emitted } = runNoolsLib(config);
-
-        // then
-        expect(emitted[0]).to.nested.include({
-          'actions[0].content.source_id': 'r-1',
-          resolved: false,//not resolved
-        });
-
-        //given
-        const resolvingReport = aReport();
-        resolvingReport.form = 'example-form';
-        resolvingReport.reported_date = TEST_DATE + 1;
-
-        //when
-        config.c.reports.push(resolvingReport);
-        let emittedAgain = runNoolsLib(config).emitted;
-
-        //then
-        expect(emittedAgain[0].resolved).to.be.false;//still not resolved
-
-        //when
-        config.tasks[0].resolvedIf = function (contact, report, event, dueDate) {
-          return this.defaultResolvedIf(contact, report, event, dueDate);
-        };
-        emittedAgain = runNoolsLib(config).emitted;
-
-        //then
-        expect(emittedAgain[0].resolved).to.be.true;//resolved
-
-      });
-
-      it('this.defaultResolvedIf can be used with specific resolving form', () => {
-        // given
-        const config = {
-          c: personWithReports(aReport()),
-          targets: [],
-          tasks: [aReportBasedTask()],
-        };
-
-        config.tasks[0].resolvedIf = function (contact, report, event, dueDate) {
-          return this.defaultResolvedIf(contact, report, event, dueDate, 'specific-form');
-        };
-
-        // when
-        const { emitted } = runNoolsLib(config);
-
-        // then
-        expect(emitted[0]).to.nested.include({
-          'actions[0].content.source_id': 'r-1',
-          resolved: false,//not resolved
-        });
-
-        //given
-        const resolvingReport = aReport();
-        resolvingReport.form = 'specific-form';
-        resolvingReport.reported_date = TEST_DATE + 1;
-
-        //when
-        config.c.reports.push(resolvingReport);
-        let emittedAgain = runNoolsLib(config).emitted;
-
-        //then
-        expect(emittedAgain[0].resolved).to.be.true;//resolved
-
-      });
-
+      
       it('should emit once per report', () => {
         // given
         const config = {
@@ -505,34 +387,6 @@ describe('task-emitter', () => {
         const expected = new Date();
         expected.setHours(0, 0, 0, 0);
         expect(emitted[0].date.getTime()).to.eq(expected.getTime());
-      });
-
-      it('given task definition without resolved_date, resolvedIf defaults to default and resolves the task', () => {
-        sinon.useFakeTimers();
-
-        // given
-        const config = {
-          c: personWithReports(aReport()),
-          targets: [],
-          tasks: [aPersonBasedTask()],
-        };
-        delete config.tasks[0].resolvedIf;
-        // when
-        const { emitted } = runNoolsLib(config);
-
-        //then
-        expect(emitted[0].resolved).to.be.false;
-        
-        //given
-        const resolvingReport = aReport();
-        resolvingReport.form = 'example-form';
-
-        //when
-        config.c.reports.push(resolvingReport);
-        const emittedAgain = runNoolsLib(config).emitted;
-
-        //then
-        expect(emittedAgain[0].resolved).to.be.true;
       });
 
       it('dueDate function is invoked with expected data', () => {
@@ -813,6 +667,72 @@ describe('task-emitter', () => {
 
         // should throw error
         assert.throws(() => { runNoolsLib(config); }, Error, 'Unrecognised task.appliesTo: unknown');
+      });
+    });
+
+    describe('defaultResolvedIf', () => {
+      it('given task definition without resolved_date, resolvedIf defaults to default and resolves the task', () => {
+        sinon.useFakeTimers();
+
+        // given
+        const config = {
+          c: personWithReports(aReport()),
+          targets: [],
+          tasks: [aPersonBasedTask()],
+          utilsMock
+        };
+        delete config.tasks[0].resolvedIf;
+        // when
+        const { emitted } = runNoolsLib(config);
+        //then
+
+        expect(utilsMock.isFormSubmittedInWindow.callCount).to.equal(1);
+        expect(emitted[0].resolved).to.be.true;
+      });
+
+      it('this.definition.defaultResolvedIf can be used inside resolvedIf', () => {
+        // given
+        const config = {
+          c: personWithReports(aReport()),
+          targets: [],
+          tasks: [aReportBasedTask()],
+          utilsMock
+        };
+
+        config.tasks[0].resolvedIf = function (contact, report, event, dueDate) {
+          return this.definition.defaultResolvedIf(contact, report, event, dueDate) && false;//never resolved
+        };
+
+        // when
+        const { emitted } = runNoolsLib(config);
+
+        // then
+        expect(emitted[0]).to.nested.include({
+          'actions[0].content.source_id': 'r-1',
+          resolved: false,//not resolved
+        });
+
+        //given
+        const resolvingReport = aReport();
+        resolvingReport.form = 'example-form';
+        resolvingReport.reported_date = TEST_DATE + 1;
+
+        //when
+        config.c.reports.push(resolvingReport);
+        let emittedAgain = runNoolsLib(config).emitted;
+
+        //then
+        expect(emittedAgain[0].resolved).to.be.false;//still not resolved
+
+        //when
+        config.tasks[0].resolvedIf = function (contact, report, event, dueDate) {
+          return this.definition.defaultResolvedIf(contact, report, event, dueDate);
+        };
+        emittedAgain = runNoolsLib(config).emitted;
+
+        //then
+        expect(emittedAgain[0].resolved).to.be.true;//resolved
+
       });
     });
 

--- a/test/nools/task-emitter.spec.js
+++ b/test/nools/task-emitter.spec.js
@@ -2,6 +2,7 @@ const chai = require('chai');
 const sinon = require('sinon');
 const runNoolsLib = require('../run-nools-lib');
 const {
+  TEST_DATE,
   TEST_DAY,
   reset,
   aReportBasedTask,
@@ -287,6 +288,136 @@ describe('task-emitter', () => {
         });
       });
 
+      it('resolvedIf is not required', () => {
+        // given
+        const config = {
+          c: personWithReports(aReport()),
+          targets: [],
+          tasks: [aReportBasedTask()],
+        };
+        delete config.tasks[0].resolvedIf;
+
+        // when
+        const { emitted } = runNoolsLib(config);
+
+        // then
+        expect(emitted[0]).to.nested.include({
+          'actions[0].content.source_id': 'r-1',
+          resolved: false,
+        });
+      });
+
+      it('this.defaultResolvedIf can be passed to resolvedIf', () => {
+        // given
+        const config = {
+          c: personWithReports(aReport()),
+          targets: [],
+          tasks: [aReportBasedTask()],
+        };
+
+        config.tasks[0].resolvedIf = this.defaultResolvedIf;
+
+        // when
+        const { emitted } = runNoolsLib(config);
+
+        // then
+        expect(emitted[0]).to.nested.include({
+          'actions[0].content.source_id': 'r-1',
+          resolved: false,
+        });
+
+        //given
+        const resolvingReport = aReport();
+        resolvingReport.form = 'example-form';
+        resolvingReport.reported_date = TEST_DATE + 1;
+
+        //when
+        config.c.reports.push(resolvingReport);
+        const emittedAgain = runNoolsLib(config).emitted;
+
+        //then
+        expect(emittedAgain[0].resolved).to.be.true;
+      });
+
+      it('this.defaultResolvedIf can be used inside resolvedIf', () => {
+        // given
+        const config = {
+          c: personWithReports(aReport()),
+          targets: [],
+          tasks: [aReportBasedTask()],
+        };
+
+        config.tasks[0].resolvedIf = function (contact, report, event, dueDate) {
+          return this.defaultResolvedIf(contact, report, event, dueDate) && false;//never resolved
+        };
+
+        // when
+        const { emitted } = runNoolsLib(config);
+
+        // then
+        expect(emitted[0]).to.nested.include({
+          'actions[0].content.source_id': 'r-1',
+          resolved: false,//not resolved
+        });
+
+        //given
+        const resolvingReport = aReport();
+        resolvingReport.form = 'example-form';
+        resolvingReport.reported_date = TEST_DATE + 1;
+
+        //when
+        config.c.reports.push(resolvingReport);
+        let emittedAgain = runNoolsLib(config).emitted;
+
+        //then
+        expect(emittedAgain[0].resolved).to.be.false;//still not resolved
+
+        //when
+        config.tasks[0].resolvedIf = function (contact, report, event, dueDate) {
+          return this.defaultResolvedIf(contact, report, event, dueDate);
+        };
+        emittedAgain = runNoolsLib(config).emitted;
+
+        //then
+        expect(emittedAgain[0].resolved).to.be.true;//resolved
+
+      });
+
+      it('this.defaultResolvedIf can be used with specific resolving form', () => {
+        // given
+        const config = {
+          c: personWithReports(aReport()),
+          targets: [],
+          tasks: [aReportBasedTask()],
+        };
+
+        config.tasks[0].resolvedIf = function (contact, report, event, dueDate) {
+          return this.defaultResolvedIf(contact, report, event, dueDate, 'specific-form');
+        };
+
+        // when
+        const { emitted } = runNoolsLib(config);
+
+        // then
+        expect(emitted[0]).to.nested.include({
+          'actions[0].content.source_id': 'r-1',
+          resolved: false,//not resolved
+        });
+
+        //given
+        const resolvingReport = aReport();
+        resolvingReport.form = 'specific-form';
+        resolvingReport.reported_date = TEST_DATE + 1;
+
+        //when
+        config.c.reports.push(resolvingReport);
+        let emittedAgain = runNoolsLib(config).emitted;
+
+        //then
+        expect(emittedAgain[0].resolved).to.be.true;//resolved
+
+      });
+
       it('should emit once per report', () => {
         // given
         const config = {
@@ -374,6 +505,34 @@ describe('task-emitter', () => {
         const expected = new Date();
         expected.setHours(0, 0, 0, 0);
         expect(emitted[0].date.getTime()).to.eq(expected.getTime());
+      });
+
+      it('given task definition without resolved_date, resolvedIf defaults to default and resolves the task', () => {
+        sinon.useFakeTimers();
+
+        // given
+        const config = {
+          c: personWithReports(aReport()),
+          targets: [],
+          tasks: [aPersonBasedTask()],
+        };
+        delete config.tasks[0].resolvedIf;
+        // when
+        const { emitted } = runNoolsLib(config);
+
+        //then
+        expect(emitted[0].resolved).to.be.false;
+        
+        //given
+        const resolvingReport = aReport();
+        resolvingReport.form = 'example-form';
+
+        //when
+        config.c.reports.push(resolvingReport);
+        const emittedAgain = runNoolsLib(config).emitted;
+
+        //then
+        expect(emittedAgain[0].resolved).to.be.true;
       });
 
       it('dueDate function is invoked with expected data', () => {

--- a/test/run-nools-lib.js
+++ b/test/run-nools-lib.js
@@ -11,9 +11,6 @@ const runNoolsLib = ({ c, targets, tasks, utilsMock }) => {
     targets,
     tasks,
     Utils: () => {
-      if (utilsMock) {
-        return utilsMock;
-      }
       //TODO: preferred way is to use 'utilsMocks' and this one will be removed when the unit test are aligned with the new approach
       return {
         addDate: function(date, days) {

--- a/test/run-nools-lib.js
+++ b/test/run-nools-lib.js
@@ -14,6 +14,7 @@ const runNoolsLib = ({ c, targets, tasks, utilsMock }) => {
       if (utilsMock) {
         return utilsMock;
       }
+      //TODO: preferred way is to use 'utilsMocks' and this one will be removed when the unit test are aligned with the new approach
       return {
         addDate: function(date, days) {
           const d = new Date(date.getTime());
@@ -47,8 +48,10 @@ const runNoolsLib = ({ c, targets, tasks, utilsMock }) => {
     },
   };
 
-  targetEmitter(context.targets, context.c, context.Utils(), context.Target, context.emit);
-  taskEmitter(context.tasks, context.c, context.Utils(), context.Task, context.emit);
+  //context.Utils is deprecated, please use utilsMock in unit tests
+  targetEmitter(context.targets, context.c, utilsMock || context.Utils(), context.Target, context.emit);
+  // context.Utils is deprecated, please use utilsMock in unit tests
+  taskEmitter(context.tasks, context.c, utilsMock || context.Utils(), context.Task, context.emit);
   context.emit('_complete', { _id: true });
 
   return { emitted };

--- a/test/run-nools-lib.js
+++ b/test/run-nools-lib.js
@@ -19,6 +19,20 @@ const runNoolsLib = ({ c, targets, tasks }) => {
       },
       now: () => new Date(TEST_DATE),
       isTimely: function() { return true; },
+      isFormSubmittedInWindow: function(reports, form, start, end, count) {
+        let result = false;
+        reports.forEach(function(report) {
+          if (!result && report.form === form) {
+            if (report.reported_date >= start && report.reported_date <= end) {
+              if (!count ||
+                 (count && report.fields && report.fields.follow_up_count > count)) {
+                result = true;
+              }
+            }
+          }
+        });
+        return result;
+      },
     },
     Target: function(props) {
       this._id = props._id;


### PR DESCRIPTION
# Description

Adds a default resolvedIf function for tasks.

Issue medic/medic-conf#107

Documentation PR: medic/cht-docs#466

## defaultResolvedIf
- Uses [Utils.isFormSubmittedInWindow](https://github.com/medic/medic-nootils/blob/4339b25201bfbf51eef9179c8b7e0e92734a0d48/src/nootils.js#L57) to check if the resolving form has been submitted within a time period:
    - For contact-based tasks, the period is the same as the task window period
    - For report based tasks, the period is determined as follows:
        - start: start of the task window or 1 millisecond after reported date of the source report, whichever comes later
        - end: end of the task window
    - The resolving form is the task's first action form with 'report' type


## Usage
Options:
A. Skip `resolvedIf` section in the task definition, `defaultResolvedIf` will be used automatically
B. Using `this.defaultResolvedIf`:
1. Without specifying the parameters:
    ```
    resolvedIf: this.defaultResolvedIf,
    ```

2. Specifying parameters and optionally adding other conditions:
    ```
    resolvedIf: function (contact, report, event, dueDate) {
      return this.defaultResolvedIf(contact, report, event, dueDate) && ...
    },
    ```
3. Specifying the resolving form type if it is different from the default (form type specified in the first action of the task):
    ```
    resolvedIf: function (contact, report, event, dueDate) {
      return this.defaultResolvedIf(contact, report, event, dueDate, 'delivery');
    },
    ```

# Code review items

- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or integration tests where appropriate
- [x] Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes

.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
