### PR TITLE
Update eslint to recognise a new global in contact summary

### DIFF
--- a/src/contact-summary/.eslintrc
+++ b/src/contact-summary/.eslintrc
@@ -32,6 +32,7 @@
     "contact": true,
     "reports": true,
     "lineage": true,
+    "uhcStats": true,
     "targetDoc": true
   }
 }


### PR DESCRIPTION
# Description

A new variable called `uhcStats` is introduced the contact-summary script scope and this PR adds support in the eslint.

The [PR in cht-core](https://github.com/medic/cht-core/pull/7053) needs to be merged before this one.

https://github.com/medic/cht-core/issues/6919

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
