### PR TITLE
396 - XForm validations don't fail if archive mode

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -175,10 +175,15 @@ const api = {
   }
 };
 
-Object.keys(api).forEach(key => {
-  if (!archivingApi[key]) {
-    archivingApi[key] = () => { throw Error('not supported in --archive mode'); };
-  }
-});
+Object.entries(api)
+  .filter(([key, value]) => typeof value === 'function' && !archivingApi[key])
+  .forEach(([key, ]) => {
+    archivingApi[key] = () => {
+      // if this error is raised, somebody forgot to add a mock
+      // implementation to ./archiving-api.js or the action isn't
+      // implemented right when archive mode is running :-(
+      throw Error(`${key} not supported in --archive mode`);
+    };
+  });
 
 module.exports = () => environment.isArchiveMode ? archivingApi : api;

--- a/src/lib/archiving-api.js
+++ b/src/lib/archiving-api.js
@@ -1,3 +1,17 @@
+/**
+ * archivingApi allows medic-conf to run when API is not available. Instead of making all actions aware of
+ * the --archive mode, this API returns mocked response that mimic successful actions.
+ *
+ * Data that would upload to API is saved to disk as an archive. The API uses one such archive when
+ * it starts to deploy a default configuration.
+ *
+ * So this module implements some methods from the ./api.js module which are used by medic-conf actions,
+ * and when medic-conf is executed with the `--archive` flag, this implementation is used instead
+ * of ./api.js.
+ *
+ * See ./archiving-api.js
+ */
+
 const archiveDocToFile = require('./archive-doc-to-file');
 const environment = require('./environment');
 
@@ -10,6 +24,17 @@ const archivingApi = {
   version() {
     return '1000.0.0'; // assume the latest version when archiving
   },
+
+  formsValidate: () => {
+    // There is no need to validate the forms
+    // in --archive mode, so the forms are
+    // considered valid
+    return Promise.resolve({ok: true});
+  },
+
+  async getCompressibleTypes () {
+    return [];
+  }
 };
 
 module.exports = archivingApi;

--- a/src/lib/archiving-db.js
+++ b/src/lib/archiving-db.js
@@ -1,10 +1,18 @@
-/*
-ArchivingDB allows medic-conf to run when API is not available. Instead of making all actions aware of the --archive mode, this "database returns 
-mocked response that an empty database would return. Data that would upload to API is saved to disk as an archive. The API uses one such archive when
-it starts to deploy a default configuration.
+/**
+ * ArchivingDB allows medic-conf to run when API is not available. Instead of making all actions aware of
+ * the --archive mode, this database returns mocked response that an empty database would return.
+ *
+ * Data that would upload to API is saved to disk as an archive. The API uses one such archive when
+ * it starts to deploy a default configuration.
+ *
+ * So this class implements the interfaces from the PouchDB class which are used by medic-conf actions,
+ * and when medic-conf is executed with the `--archive` flag, this implementation is used instead
+ * of PouchDB.
+ *
+ * Archive mode is used by the default grant task in the CHT, see the `exec:build-config`
+ * task at the https://github.com/medic/cht-core/blob/master/Gruntfile.js file.
+ */
 
-This class implements the interfaces from the PouchDB object which are used by medic-conf actions.
-*/
 const archiveDocToFile = require('./archive-doc-to-file');
 
 class ArchivingDB {

--- a/src/lib/environment.js
+++ b/src/lib/environment.js
@@ -30,17 +30,27 @@ const initialize = (
   });
 };
 
+const getState = prop => {
+  if (!state.initialized) {
+    // If this exception is raised, it means that the use of any method of this
+    // module was earlier than the state initialization, so the problem is not of
+    // how medic-conf was invoked by the user, but a bug introduced in the code
+    throw new Error(`Cannot return environment.${prop}: state was not initialized yet`);
+  }
+  return state[prop];
+};
+
 module.exports = {
   initialize,
 
-  get pathToProject() { return state.pathToProject || '.'; },
-  get isArchiveMode() { return !!state.isArchiveMode; },
-  get archiveDestination() { return state.archiveDestination; },
+  get pathToProject() { return getState('pathToProject') || '.'; },
+  get isArchiveMode() { return !!getState('isArchiveMode'); },
+  get archiveDestination() { return getState('archiveDestination'); },
   get instanceUrl() { return this.apiUrl && this.apiUrl.replace(/\/medic$/, ''); },
-  get extraArgs() { return state.extraArgs; },
-  get apiUrl() { return state.apiUrl; },
-  get force() { return state.force; },
-  get skipTranslationCheck() { return state.skipTranslationCheck; },
+  get extraArgs() { return getState('extraArgs'); },
+  get apiUrl() { return getState('apiUrl'); },
+  get force() { return getState('force'); },
+  get skipTranslationCheck() { return getState('skipTranslationCheck'); },
 
   /**
    * Return `true` if the environment **seems** to be production.

--- a/src/lib/get-api-url.js
+++ b/src/lib/get-api-url.js
@@ -13,17 +13,17 @@ const getApiUrl = (cmdArgs, env = {}) => {
     return false;
   }
 
-  if (cmdArgs.archive) {
-    return '--archive mode';
-  }
-
   if (cmdArgs.user && !cmdArgs.instance) {
     error('The --user switch can only be used if followed by --instance');
     return false;
   }
 
   let instanceUrl;
-  if (cmdArgs.local) {
+  if (cmdArgs.local || cmdArgs.archive) {
+    // Although `--archive` mode won't connect with the
+    // local database, a URL is required to mimic the
+    // behaviour as it is connecting to.
+    // See ./archiving-db.js
     instanceUrl = parseLocalUrl(env.COUCH_URL);
     if (instanceUrl.hostname !== 'localhost') {
       error(`You asked to configure localhost, but the COUCH_URL env var is set to '${instanceUrl.hostname}'.  This may be a remote server.`);

--- a/src/lib/validate-forms.js
+++ b/src/lib/validate-forms.js
@@ -1,4 +1,4 @@
-const api = require('./api')();
+const api = require('./api');
 const argsFormFilter = require('./args-form-filter');
 const fs = require('./sync-fs');
 const log = require('./log');
@@ -54,7 +54,7 @@ module.exports = async (projectDir, subDirectory, options={}) => {
 
 let validateEndpointNotFoundLogged = false;
 const _formsValidate = async (xml) => {
-  const resp = await api.formsValidate(xml);
+  const resp = await api().formsValidate(xml);
   if (resp.formsValidateEndpointFound === false && !validateEndpointNotFoundLogged) {
     log.warn('Form validation endpoint not found in your version of CHT Core, ' +
       'no form will be checked before push');

--- a/src/lib/warn-upload-overwrite.js
+++ b/src/lib/warn-upload-overwrite.js
@@ -1,3 +1,4 @@
+const api = require('./api');
 const fs = require('./sync-fs');
 const jsonDiff = require('json-diff');
 const userPrompt = require('./user-prompt');
@@ -8,8 +9,6 @@ const log = require('./log');
 const environment = require('./environment');
 const { compare, GroupingReporter } = require('dom-compare');
 const DOMParser = require('xmldom').DOMParser;
-const request = require('request-promise-native');
-const cache = new Map();
 
 const question = 'You are trying to modify a configuration that has been modified since your last upload. Do you want to?';
 const responseChoicesWithoutDiff = [
@@ -22,26 +21,6 @@ const getEnvironmentKey = () => {
   const parsed = new url.URL(environment.apiUrl);
   const path = parsed.pathname && parsed.pathname !== '/' ? parsed.pathname : '/medic';
   return `${parsed.hostname}${path}`;
-};
-
-const getCompressibleTypes = async () => {
-  const parsedUrl = new url.URL(environment.apiUrl);
-  const configUrl = `${parsedUrl.protocol}//${parsedUrl.username}:${parsedUrl.password}@${parsedUrl.host}/api/couch-config-attachments`;
-  try {
-    if (cache.has('compressibleTypes')) {
-      return cache.get('compressibleTypes');
-    }
-    const resp = await request.get({ url: configUrl, json: true });
-    cache.set('compressibleTypes', resp.compressible_types);
-    return resp.compressible_types;
-  } catch(e) {
-    if (e.statusCode === 404) {
-      cache.set('compressibleTypes', null);
-    } else {
-      log.error(`Error trying to get couchdb config: ${e}`);
-    }
-    return null;
-  }
 };
 
 const getHashFileName = () => {
@@ -122,17 +101,16 @@ const getDocHash = async (db, originalDoc) => {
   delete doc._attachments;
   const crypt = crypto.createHash('md5');
   crypt.update(JSON.stringify(doc), 'utf8');
-  const compressibleTypes = await getCompressibleTypes();
-  const matchRegex = (pattern, type) => {
-    const rx = new RegExp(pattern.trim());
-    return rx.test(type);
-  };
+  const compressibleTypes = await api().getCompressibleTypes();
   if (originalDoc._attachments) {
+    const matchRegex = (pattern, type) => {
+      const rx = new RegExp(pattern);
+      return rx.test(type);
+    };
     for (const attachmentName of Object.keys(originalDoc._attachments)) {
       const attachment = originalDoc._attachments[attachmentName];
-      const attachmentCompressible = compressibleTypes ?
-        compressibleTypes.split(',').some(c => matchRegex(c, attachment.content_type)) :
-        true;
+      const attachmentCompressible = compressibleTypes.length ?
+          compressibleTypes.some(c => matchRegex(c, attachment.content_type)) : true;
       if (attachmentCompressible) {
         const data = attachment.data ? attachment.data : await db.getAttachment(originalDoc._id, attachmentName);
         crypt.update(data);

--- a/test/fn/compile-app-settings.spec.js
+++ b/test/fn/compile-app-settings.spec.js
@@ -81,6 +81,7 @@ describe('compile-app-settings', () => {
 async function test(relativeProjectDir) {
   const testDir = path.join(__dirname, '../data/compile-app-settings', relativeProjectDir);
   sinon.stub(environment, 'pathToProject').get(() => testDir);
+  sinon.stub(environment, 'extraArgs').get(() => undefined);
 
   // when
   await compileAppSettings.execute();

--- a/test/fn/convert-forms.utils.js
+++ b/test/fn/convert-forms.utils.js
@@ -35,6 +35,7 @@ module.exports = {
 
       before(() => {
         sinon.stub(environment, 'pathToProject').get(() => projectDir);
+        sinon.stub(environment, 'extraArgs').get(() => undefined);
         return convertForms.execute();
       });
 

--- a/test/fn/create-users.spec.js
+++ b/test/fn/create-users.spec.js
@@ -15,6 +15,8 @@ const mockTestDir = testDir => sinon.stub(environment, 'pathToProject').get(() =
 describe('create-users', () => {
   beforeEach(() => {
     createUsers.__set__('userPrompt', userPrompt);
+    sinon.stub(environment, 'isArchiveMode').get(() => false);
+    sinon.stub(environment, 'force').get(() => false);
     return api.start();
   });
   afterEach(() => {

--- a/test/fn/edit-contacts.spec.js
+++ b/test/fn/edit-contacts.spec.js
@@ -59,7 +59,8 @@ describe('edit-contacts', function() {
   });
 
   it(`should do a top-down test well and add all available columns to the docs since they are not specified`, async function(){
-
+    sinon.stub(environment, 'force').get(() => false);
+    sinon.stub(environment, 'extraArgs').get(() => undefined);
     await editContactsModule.execute();
     assert.equal(countFilesInDir(saveDocsDir),
                 countFilesInDir(expectedDocsDirAllCols),

--- a/test/fn/initialise-project-layout.spec.js
+++ b/test/fn/initialise-project-layout.spec.js
@@ -12,7 +12,7 @@ const initialiseProjectLayout = require('../../src/fn/initialise-project-layout'
 describe('initialise-project-layout', () => {
   it('should create a project with the desired layout', () => {
     // when
-
+    sinon.stub(environment, 'extraArgs').get(() => undefined);
     sinon.stub(environment, 'pathToProject').get(() => TARGET_DIR);
     initialiseProjectLayout.execute();
 

--- a/test/fn/move-contacts.spec.js
+++ b/test/fn/move-contacts.spec.js
@@ -555,6 +555,7 @@ describe('move-contacts', () => {
 
     it('does not delete files in directory when user presses n', () => {
       readline.keyInYN.returns(false);
+      sinon.stub(environment, 'force').get(() => false);
       prepareDocDir(docOnj);
       assert.equal(fs.deleteFilesInFolder.callCount, 0);
       assert.equal(process.exit.callCount, 1);
@@ -562,6 +563,7 @@ describe('move-contacts', () => {
 
     it('deletes files in directory when user presses y', () => {
       readline.keyInYN.returns(true);
+      sinon.stub(environment, 'force').get(() => false);
       prepareDocDir(docOnj);
       assert.equal(fs.deleteFilesInFolder.callCount, 1);
       assert.equal(process.exit.callCount, 0);

--- a/test/fn/upload-branding.spec.js
+++ b/test/fn/upload-branding.spec.js
@@ -10,6 +10,7 @@ describe('Upload Branding', () => {
   });
 
   it('should call uploadConfigurationDocs with expected parameters', async () => {
+    sinon.stub(environment, 'pathToProject').get(() => '.');
     const configurationPath = `${environment.pathToProject}/branding.json`;
     const directoryPath = `${environment.pathToProject}/branding`;
     const dbDocName = 'branding';

--- a/test/fn/upload-docs.spec.js
+++ b/test/fn/upload-docs.spec.js
@@ -3,6 +3,7 @@ const rewire = require('rewire');
 const sinon = require('sinon');
 
 const api = require('../api-stub');
+const environment = require('../../src/lib/environment');
 const uploadDocs = rewire('../../src/fn/upload-docs');
 const userPrompt = rewire('../../src/lib/user-prompt');
 let readLine = { keyInYN: () => true };
@@ -13,6 +14,10 @@ describe('upload-docs', function() {
   let fs;
 
   beforeEach(() => {
+    sinon.stub(environment, 'isArchiveMode').get(() => false);
+    sinon.stub(environment, 'extraArgs').get(() => undefined);
+    sinon.stub(environment, 'pathToProject').get(() => '.');
+    sinon.stub(environment, 'force').get(() => false);
     api.start();
     fs = {
       exists: () => true,

--- a/test/fn/upload-partners.spec.js
+++ b/test/fn/upload-partners.spec.js
@@ -10,6 +10,7 @@ describe('Upload Partners', () => {
   });
 
   it('should call uploadConfigurationDocs with expected parameters', async () => {
+    sinon.stub(environment, 'pathToProject').get(() => '.');
     const configurationPath = `${environment.pathToProject}/partners.json`;
     const directoryPath = `${environment.pathToProject}/partners`;
     const dbDocName = 'partners';

--- a/test/fn/upload-privacy-policies.spec.js
+++ b/test/fn/upload-privacy-policies.spec.js
@@ -15,6 +15,7 @@ const getDoc = () => api.db.get('privacy-policies', { attachments: true });
 
 describe('upload privacy policies', () => {
   beforeEach(() => {
+    sinon.stub(environment, 'isArchiveMode').get(() => false);
     sinon.stub(warnUploadOverwrite, 'preUploadDoc');
     sinon.stub(warnUploadOverwrite, 'postUploadDoc');
     sinon.spy(logger, 'info');

--- a/test/fn/upload-resources.spec.js
+++ b/test/fn/upload-resources.spec.js
@@ -10,6 +10,7 @@ describe('Upload Resources', () => {
   });
 
   it('should call uploadConfigurationDocs with expected parameters', async () => {
+    sinon.stub(environment, 'pathToProject').get(() => '.');
     const configurationPath = `${environment.pathToProject}/resources.json`;
     const directoryPath = `${environment.pathToProject}/resources`;
     const dbDocName = 'resources';

--- a/test/fn/upload-sms-from-csv.spec.js
+++ b/test/fn/upload-sms-from-csv.spec.js
@@ -18,6 +18,8 @@ describe('upload-sms-from-csv', function() {
     // given
     const testDir = 'data/upload-sms-from-csv';
     sinon.stub(environment, 'pathToProject').get(() => testDir);
+    sinon.stub(environment, 'extraArgs').get(() => undefined);
+    sinon.stub(environment, 'isArchiveMode').get(() => false);
 
     // when
     return csvToSms.execute()

--- a/test/lib/api.spec.js
+++ b/test/lib/api.spec.js
@@ -75,7 +75,7 @@ describe('api', () => {
     });
 
     it('throws not supported for undefined interfaces', () => {
-      expect(api().getAppSettings).to.throw('not supported');
+      expect(api().getAppSettings).to.throw('getAppSettings not supported in --archive mode');
     });
   });
 

--- a/test/lib/environment.spec.js
+++ b/test/lib/environment.spec.js
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+const { assert, expect } = require('chai');
 const environment = require('../../src/lib/environment');
 const sinon = require('sinon');
 
@@ -6,7 +6,18 @@ describe('environment', () => {
 
   afterEach(sinon.restore);
 
-  describe('isProduction',  () => {
+  describe('initialization', () => {
+    it('raise error if getter is invoked before initialization', () => {
+      try {
+        environment.apiUrl;
+        assert.fail('Expected Error to be thrown.');
+      } catch (e) {
+        expect(e.message).to.be.equal('Cannot return environment.apiUrl: state was not initialized yet');
+      }
+    });
+  });
+
+  describe('isProduction', () => {
 
     it('localhost and port environment return false', () => {
       sinon.stub(environment, 'instanceUrl').get(() => 'http://admin:pass@localhost:5988');

--- a/test/lib/main.spec.js
+++ b/test/lib/main.spec.js
@@ -4,24 +4,19 @@ const { expect } = require('chai');
 
 const environment = rewire('../../src/lib/environment');
 const main = rewire('../../src/lib/main');
-const userPrompt = rewire('../../src/lib/user-prompt');
+const userPrompt = require('../../src/lib/user-prompt');
 
 const defaultActions = main.__get__('defaultActions');
 const normalArgv = ['node', 'medic-conf'];
 
 let mocks;
-let readline;
 describe('main', () => {
   beforeEach(() => {
-    readline = {
-      question: sinon.stub().returns('pwd'),
-      keyInYN: sinon.stub().returns(true)
-    };
     environment.__set__('state', {});
     sinon.spy(environment, 'initialize');
-    userPrompt.__set__('readline', readline);
+    sinon.stub(userPrompt, 'question').returns('pwd');
+    sinon.stub(userPrompt, 'keyInYN').returns(true);
     mocks = {
-      userPrompt: userPrompt,
       usage: sinon.stub(),
       shellCompletionSetup: sinon.stub(),
       error: sinon.stub(),
@@ -45,6 +40,7 @@ describe('main', () => {
   });
   afterEach(() => {
     environment.initialize.restore();
+    sinon.restore();
   });
 
   it('no argv yields usage', async () => {
@@ -158,7 +154,7 @@ describe('main', () => {
     it('single action', async () => {
       await main([...normalArgv, '--archive', '--destination=foo', 'upload-app-settings'], {});
       expectExecuteActionBehavior('upload-app-settings', undefined, true);
-      expect(readline.keyInYN.callCount).to.eq(0);
+      expect(userPrompt.keyInYN.callCount).to.eq(0);
     });
 
     it('requires destination', async () => {
@@ -170,17 +166,17 @@ describe('main', () => {
 
   it('accept non-matching instance warning', async () => {
     mocks.getApiUrl.returns('https://admin:pwd@url.app.medicmobile.org/medic');
-    readline.keyInYN.returns(true);
+    userPrompt.keyInYN.returns(true);
     const actual = await main([...normalArgv, '---url=https://admin:pwd@url.app.medicmobile.org/']);
-    expect(readline.keyInYN.callCount).to.eq(1);
+    expect(userPrompt.keyInYN.callCount).to.eq(1);
     expect(actual).to.be.undefined;
   });
 
   it('reject non-matching instance warning', async () => {
     mocks.getApiUrl.returns('https://admin:pwd@url.app.medicmobile.org/medic');
-    readline.keyInYN.returns(false);
+    userPrompt.keyInYN.returns(false);
     const actual = await main([...normalArgv, '---url=https://admin:pwd@url.app.medicmobile.org/']);
-    expect(readline.keyInYN.callCount).to.eq(1);
+    expect(userPrompt.keyInYN.callCount).to.eq(1);
     expect(actual).to.eq(false);
   });
 
@@ -188,7 +184,7 @@ describe('main', () => {
     mocks.getApiUrl.returns('https://admin:pwd@url.app.medicmobile.org/medic');
     environment.__set__('force', true);
     const actual = await main([...normalArgv, '---url=https://admin:pwd@url.app.medicmobile.org/', '--force']);
-    expect(readline.keyInYN.callCount).to.eq(1);
+    expect(userPrompt.keyInYN.callCount).to.eq(1);
     expect(actual).to.be.undefined;
   });
 });

--- a/test/lib/upload-forms.spec.js
+++ b/test/lib/upload-forms.spec.js
@@ -3,6 +3,7 @@ const rewire = require('rewire');
 const sinon = require('sinon');
 
 const api = require('../api-stub');
+const environment = require('../../src/lib/environment');
 const uploadForms = rewire('../../src/lib/upload-forms');
 const log = require('../../src/lib/log');
 
@@ -21,6 +22,7 @@ describe('upload-forms', () => {
   const validateForms = sinon.stub().resolves();
 
   it('form filter limits uploaded forms', async () => {
+    sinon.stub(environment, 'isArchiveMode').get(() => false);
     const insertOrReplace = sinon.stub();
     const logWarn = sinon.stub(log, 'warn');
     return uploadForms.__with__({ insertOrReplace, validateForms })(async () => {
@@ -31,6 +33,8 @@ describe('upload-forms', () => {
   });
 
   it('should merge supported properties into form', async () => {
+    sinon.stub(environment, 'isArchiveMode').get(() => false);
+    sinon.stub(environment, 'pathToProject').get(() => '.');
     return uploadForms.__with__({ validateForms })(async () => {
       const logInfo = sinon.stub(log, 'info');
       const logWarn = sinon.stub(log, 'warn');

--- a/test/lib/validate-forms.spec.js
+++ b/test/lib/validate-forms.spec.js
@@ -35,15 +35,16 @@ describe('validate-forms', () => {
   it('should reject forms that the api validations reject', () => {
     const logInfo = sinon.stub(log, 'info');
     const logError = sinon.stub(log, 'error');
-    const apiMock = {
-      formsValidate: sinon.stub().rejects('The error')
-    };
+    const formsValidateMock = sinon.stub().rejects('The error');
+    const apiMock = () => ({
+      formsValidate: formsValidateMock
+    });
     return validateForms.__with__({api: apiMock})(async () => {
       try {
         await validateForms(`${BASE_DIR}/merge-properties`, FORMS_SUBDIR);
         assert.fail('Expected Error to be thrown.');
       } catch (e) {
-        expect(apiMock.formsValidate.called).to.be.true;
+        expect(formsValidateMock.called).to.be.true;
         assert.include(e.message, 'One or more forms appears to have errors found by the API validation endpoint.');
         assert.notInclude(e.message, 'One or more forms appears to be missing <meta><instanceID/></meta> node.');
         expect(logInfo.args[0][0]).to.equal('Validating form: example.xml…');
@@ -55,9 +56,10 @@ describe('validate-forms', () => {
   it('should execute all validations and fail with all the errors concatenated', () => {
     const logInfo = sinon.stub(log, 'info');
     const logError = sinon.stub(log, 'error');
-    const apiMock = {
-      formsValidate: sinon.stub().rejects('The error')
-    };
+    const formsValidateMock = sinon.stub().rejects('The error');
+    const apiMock = () => ({
+      formsValidate: formsValidateMock
+    });
     return validateForms.__with__({api: apiMock})(async () => {
       try {
         await validateForms(`${BASE_DIR}/good-and-bad-forms`, FORMS_SUBDIR);
@@ -74,9 +76,9 @@ describe('validate-forms', () => {
 
   it('should resolve OK if all validations pass', () => {
     const logInfo = sinon.stub(log, 'info');
-    const apiMock = {
+    const apiMock = () => ({
       formsValidate: sinon.stub().resolves({ok:true})
-    };
+    });
     return validateForms.__with__({api: apiMock})(async () => {
       await validateForms(`${BASE_DIR}/merge-properties`, FORMS_SUBDIR);
       expect(logInfo.args[0][0]).to.equal('Validating form: example.xml…');


### PR DESCRIPTION
# Description

If the user is running medic-conf in `--archive` mode and the local API is not running, avoid failing when the XForm validations are requested, and instead warn with the following message:

    WARN The CHT Core instance is not running, no form will be checked before push

Also when trying to access other API endpoints and the API is down, there were messages logged like this: `ERROR Error trying to get couchdb config: RequestError: Error: Invalid URI "null//null@null/api/couch-config-attachments"` , now the message is:

    ERROR Error trying to get couchdb config: RequestError: Error: connect ECONNREFUSED 127.0.0.1:5988

medic/medic-conf#396

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
