### PR TITLE
feat(#772): accept array in recipient

### DIFF
--- a/src/lib/validate-app-settings.js
+++ b/src/lib/validate-app-settings.js
@@ -58,7 +58,7 @@ const ScheduleSchema = joi.array().items(
         offset: joi.string().required(),
         send_day: joi.string().allow(''),
         send_time: joi.string().allow(''),
-        recipient: joi.string()
+        recipient: joi.alternatives().try(joi.string(), joi.array())
       })
     ).required()
   })

--- a/test/lib/validate-app-settings.spec.js
+++ b/test/lib/validate-app-settings.spec.js
@@ -155,6 +155,72 @@ describe('validate-app-settings', () => {
       }], '"[0].start_from" must be one of [string, array]');
     });
 
+    it('recipient as string is valid.', () => {
+      isValid([{
+        name: 'schedule name',
+        start_from: 'dob',
+        messages: [{
+          translation_key: 'a.b',
+          group: '1',
+          offset: '0',
+          recipient: 'patient'
+        }]
+      }]);
+    });
+
+    it('recipient as single array element is valid.', () => {
+      isValid([{
+        name: 'schedule name',
+        start_from: 'dob',
+        messages: [{
+          translation_key: 'a.b',
+          group: '1',
+          offset: '0',
+          recipient: ['patient']
+        }]
+      }]);
+    });
+
+    it('recipient as multiple array element is valid.', () => {
+      isValid([{
+        name: 'schedule name',
+        start_from: 'dob',
+        messages: [{
+          translation_key: 'a.b',
+          group: '1',
+          offset: '0',
+          recipient: ['patient','praent.phone','link:g30_phone']
+        }]
+      }]);
+    });   
+
+    it('recipient as a number is invalid.', () => {
+      isNotValid([{
+        name: 'schedule name',
+        start_from: 'dob',
+        messages: [{
+          translation_key: 'a.b',
+          group: '1',
+          offset: '0',
+          recipient: 98410
+        }]
+      }], '"[0].messages[0].recipient" must be one of [string, array]');
+    });
+
+    it('recipient as number within string is valid.', () => {
+      isValid([{
+        name: 'schedule name',
+        start_from: 'dob',
+        messages: [{
+          translation_key: 'a.b',
+          group: '1',
+          offset: '0',
+          recipient: '98410'
+        }]
+      }]);
+    });
+
+
   });
 
   describe('validateAssetlinks', () => {


### PR DESCRIPTION
# Description

Allow recipient to accept array along with string. 

medic/cht-conf#772

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
