### PR TITLE
fix(#790): preserve port from COUCH_URL when using --local

### DIFF
--- a/src/lib/get-api-url.js
+++ b/src/lib/get-api-url.js
@@ -55,7 +55,7 @@ const parseLocalUrl = (couchUrl) => {
   const doParse = (unparsed) => {
     const parsed = new url.URL(unparsed);
     parsed.path = parsed.pathname = '';
-    parsed.host = `${parsed.hostname}:5988`;
+    parsed.host = `${parsed.hostname}:${parsed.port || 5988}`;
     return new url.URL(url.format(parsed));
   };
 

--- a/test/lib/get-api-url.spec.js
+++ b/test/lib/get-api-url.spec.js
@@ -35,7 +35,12 @@ describe('get-api-url', () => {
 
     it('use environment variable', () => {
       const actual = apiUrlLib.getApiUrl({ local: true }, { COUCH_URL: 'http://user:pwd@localhost:5984/db' });
-      expect(actual).to.deep.equal(new url.URL('http://user:pwd@localhost:5988/medic'));
+      expect(actual).to.deep.equal(new url.URL('http://user:pwd@localhost:5984/medic'));
+    });
+
+    it('use environment variable with custom port', () => {
+      const actual = apiUrlLib.getApiUrl({ local: true }, { COUCH_URL: 'http://medic:pass@localhost:61418/medic' });
+      expect(actual).to.deep.equal(new url.URL('http://medic:pass@localhost:61418/medic'));
     });
 
     it('warn if environment variable targets remote', () => {
@@ -70,11 +75,17 @@ describe('get-api-url', () => {
     it('basic', () =>
       expect(parseLocalUrl('http://admin:pass@localhost:5988/medic').href).to.eq('http://admin:pass@localhost:5988/'));
 
-    it('updates port', () =>
-      expect(parseLocalUrl('http://admin:pass@localhost:5984/medic').href).to.eq('http://admin:pass@localhost:5988/'));
+    it('preserves port from COUCH_URL', () =>
+      expect(parseLocalUrl('http://admin:pass@localhost:5984/medic').href).to.eq('http://admin:pass@localhost:5984/'));
+
+    it('preserves custom port from COUCH_URL', () =>
+      expect(parseLocalUrl('http://admin:pass@localhost:61418/medic').href).to.eq('http://admin:pass@localhost:61418/'));
+
+    it('defaults to 5988 when no port specified', () =>
+      expect(parseLocalUrl('http://admin:pass@localhost/medic').href).to.eq('http://admin:pass@localhost:5988/'));
 
     it('ignores path', () =>
-      expect(parseLocalUrl('http://admin:pass@localhost:5984/foo').href).to.eq('http://admin:pass@localhost:5988/'));
+      expect(parseLocalUrl('http://admin:pass@localhost:5984/foo').href).to.eq('http://admin:pass@localhost:5984/'));
   });
 
   describe('isLocalhost', () => {


### PR DESCRIPTION
--local flag ignores port from COUCH_URL environment variable, always uses 5988

# Description

Closes medic/cht-conf#790

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
