### PR TITLE
chore: add e2e test for fetching forms from Google Drive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,11 @@ jobs:
   e2e:
     name: E2E tests
     runs-on: ubuntu-22.04
+    env:
+      GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      GOOGLE_REDIRECT_URI: "http://localhost"
+      GOOGLE_TOKEN_SCOPE: 'https://www.googleapis.com/auth/drive.readonly'
 
     steps:
     - uses: actions/checkout@v4
@@ -48,5 +53,21 @@ jobs:
     - name: Hard code local-ip IP in /etc/hosts per https://github.com/medic/medic-infrastructure/issues/571#issuecomment-2209120441
       run: |
         echo "15.188.129.97 local-ip.medicmobile.org" | sudo tee -a /etc/hosts
+
+    - id: auth
+      uses: google-github-actions/auth@v2
+      with:
+        service_account: ${{ env.GOOGLE_SERVICE_ACCT }}
+        credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+        token_format: access_token
+        access_token_scopes: ${{ env.GOOGLE_TOKEN_SCOPE }}
+    - name: Write access_token to .gdrive.session.json
+      run: |
+        echo '{
+          "access_token": "${{ steps.auth.outputs.access_token }}",
+          "scope": "${{ env.GOOGLE_TOKEN_SCOPE }}",
+          "token_type": "Bearer",
+          "expiry_date": "9999999999999"
+        }' > .gdrive.session.json
     - name: Run E2E tests
       run: npm run test-e2e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,8 @@ jobs:
     - name: Hard code local-ip IP in /etc/hosts per https://github.com/medic/medic-infrastructure/issues/571#issuecomment-2209120441
       run: |
         echo "15.188.129.97 local-ip.medicmobile.org" | sudo tee -a /etc/hosts
-
     - id: auth
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
       with:
         service_account: ${{ env.GOOGLE_SERVICE_ACCT }}
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}

--- a/test/e2e/.mocharc.js
+++ b/test/e2e/.mocharc.js
@@ -4,7 +4,7 @@ module.exports = {
   ...rootConfig,
   captureFile: 'test/e2e/results.txt',
   checkLeaks: true,
-  exclude: [],
+  exclude: process.env.CI ? [] : ['test/e2e/fetch-forms-from-google-drive.spec.js'], // Do not run Google tests locally by default
   file: 'test/e2e/hooks.js',
   spec: 'test/e2e/**/*.spec.js',
   timeout: 120_000, // spinning up a CHT instance takes a little long

--- a/test/e2e/fetch-forms-from-google-drive.spec.js
+++ b/test/e2e/fetch-forms-from-google-drive.spec.js
@@ -1,0 +1,53 @@
+const { expect } = require('chai');
+const fs = require('node:fs');
+const {
+  cleanupProject,
+  initProject,
+  runChtConf,
+  getProjectDirectory
+} = require('./cht-conf-utils');
+const path = require('path');
+
+const FORMS = {
+  'app/death_report.xlsx': '1azFHCMTMehxuSg_LWOgsJZxrJo0yhseLp9FK4gTT38M',
+  'contact/person-create.xlsx': '1VhOPphx4IXyZiGbcevVZwvsvap8WPKHmUjOp8NuWJW8'
+};
+
+/**
+ * Running this test locally requires OAuth desktop client credentials for a Google Cloud Project.
+ * https://docs.communityhealthtoolkit.org/apps/guides/forms/google-drive/
+ * Once you have created the OAuth client, configure the following environment variables in your current shell:
+ * `CI=true`, `GOOGLE_REDIRECT_URI=http://localhost`, and `GOOGLE_CLIENT_ID=<client_id from OAuth client>`,
+ * `GOOGLE_CLIENT_SECRET=<>`. Next, generate a `.gdrive.session.json` file with a valid access token by manually
+ * running `cht fetch-forms-from-google-drive`. Copy the `.gdrive.session.json` file to the root of the cht-conf repo.
+ * Then you should be able to successfully run `npm test-e2e`.
+ *
+ * On CI, this test runs with a configured Service Account by preemptively getting an access token and setting it in
+ * the `.gdrive.session.json` file. Unfortunately, this means these tests cannot cover the login portion of the
+ * functionality, but it does to cover the actual fetching and file writing logic.
+ */
+describe('fetch-forms-from-google-drive', () => {
+  before(initProject);
+  after(cleanupProject);
+
+  it('downloads configured forms from Google Drive', async () => {
+    const projectDir = getProjectDirectory();
+    await fs.promises.writeFile(
+      path.join(projectDir, 'forms-on-google-drive.json'),
+      JSON.stringify(FORMS, null, 2),
+    );
+
+    const sessionJsonSrcPath = path.resolve(__dirname, '../../.gdrive.session.json');
+    const sessionJsonDestPath = path.resolve(projectDir, '.gdrive.session.json');
+    await fs.promises.copyFile(sessionJsonSrcPath, sessionJsonDestPath);
+
+    await runChtConf('fetch-forms-from-google-drive');
+
+    const formFilePaths = Object
+      .keys(FORMS)
+      .map(formPath => path.join(projectDir, 'forms', formPath));
+    formFilePaths.forEach(formPath => {
+      expect(fs.existsSync(formPath)).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
# Description

The goal of this PR is to add an automated e2e test that covers at least part of the `fetch-forms-from-google-drive` action. Normally, running that action requires manually completing a Google OAuth login flow (via mandatory browser interaction).  This PR uses an approach I [prototyped in cht-config-library](https://github.com/jkuester/cht-config-library/tree/main/google-drive#ci-setup) where I use a Service Account to preemptively produce an access token that can be used by cht-conf to interact with the Google Apis (so no login flow is needed).

While this means we do not cover all of the `fetch-forms-from-google-drive` (since we bypass the login), it seems better than nothing (and at least enough to make us more confident when bumping the version of the `googleapis` dependency). 

In the long term, I think we should consider rethinking this action. Needing to create a whole Google Cloud OAuth app just to use it is a pretty steep requirement and I am not sure how useful this is to anyone....

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.