### PR TITLE
feat(#792): add upload-ui-extensions action

### DIFF
--- a/src/fn/upload-ui-extensions.js
+++ b/src/fn/upload-ui-extensions.js
@@ -1,17 +1,15 @@
-const environment = require('../lib/environment');
 const projectPaths = require('../lib/project-paths');
 const { uploadUiExtensions } = require('../lib/upload-ui-extensions');
 
-module.exports = {
-  requiresInstance: true,
-  execute: async () => {
-    const uiExtensionsDir = `${environment.pathToProject}/${projectPaths.UI_EXTENSIONS_PATH}`;
+const executeUploadUiExtensions = async (environment) => {
+  const uiExtensionsDir = `${environment.pathToProject}/${projectPaths.UI_EXTENSIONS_PATH}`;
 
-    let specificExtensions = [];
-    if (environment.extraArgs?.length) {
-      specificExtensions = environment.extraArgs.filter(arg => !arg.startsWith('--'));
-    }
-
-    await uploadUiExtensions(uiExtensionsDir, specificExtensions);
+  let specificExtensions = [];
+  if (environment.extraArgs?.length) {
+    specificExtensions = environment.extraArgs.filter(arg => !arg.startsWith('--'));
   }
+
+  await uploadUiExtensions(uiExtensionsDir, specificExtensions);
 };
+
+module.exports = executeUploadUiExtensions;

--- a/src/fn/upload-ui-extensions.js
+++ b/src/fn/upload-ui-extensions.js
@@ -9,7 +9,6 @@ module.exports = {
 
     let specificExtensions = [];
     if (environment.extraArgs?.length) {
-      // Filter out standard CLI syntax (e.g. drop the initial '--')
       specificExtensions = environment.extraArgs.filter(arg => !arg.startsWith('--'));
     }
 

--- a/src/fn/upload-ui-extensions.js
+++ b/src/fn/upload-ui-extensions.js
@@ -1,0 +1,17 @@
+const environment = require('../lib/environment');
+const projectPaths = require('../lib/project-paths');
+const uploadUiExtensions = require('../lib/upload-ui-extensions');
+
+module.exports = {
+  requiresInstance: true,
+  execute: async () => {
+    const uiExtensionsDir = `${environment.pathToProject}/${projectPaths.UI_EXTENSIONS_PATH}`;
+
+    let specificExtensions = [];
+    if (environment.extraArgs && environment.extraArgs.length) {
+      specificExtensions = environment.extraArgs.filter(arg => !arg.startsWith('--'));
+    }
+
+    await uploadUiExtensions(uiExtensionsDir, specificExtensions);
+  }
+};

--- a/src/fn/upload-ui-extensions.js
+++ b/src/fn/upload-ui-extensions.js
@@ -8,7 +8,8 @@ module.exports = {
     const uiExtensionsDir = `${environment.pathToProject}/${projectPaths.UI_EXTENSIONS_PATH}`;
 
     let specificExtensions = [];
-    if (environment.extraArgs && environment.extraArgs.length) {
+    if (environment.extraArgs?.length) {
+      // Filter out standard CLI syntax (e.g. drop the initial '--')
       specificExtensions = environment.extraArgs.filter(arg => !arg.startsWith('--'));
     }
 

--- a/src/fn/upload-ui-extensions.js
+++ b/src/fn/upload-ui-extensions.js
@@ -1,6 +1,6 @@
 const environment = require('../lib/environment');
 const projectPaths = require('../lib/project-paths');
-const uploadUiExtensions = require('../lib/upload-ui-extensions');
+const { uploadUiExtensions } = require('../lib/upload-ui-extensions');
 
 module.exports = {
   requiresInstance: true,

--- a/src/fn/upload-ui-extensions.js
+++ b/src/fn/upload-ui-extensions.js
@@ -1,7 +1,9 @@
 const projectPaths = require('../lib/project-paths');
-const { uploadUiExtensions } = require('../lib/upload-ui-extensions');
+const uploadUiExtensionsLib = require('../lib/upload-ui-extensions');
+const environment = require('../lib/environment');
 
-const executeUploadUiExtensions = async (environment) => {
+
+const executeUploadUiExtensions = async () => {
   const uiExtensionsDir = `${environment.pathToProject}/${projectPaths.UI_EXTENSIONS_PATH}`;
 
   let specificExtensions = [];
@@ -9,7 +11,10 @@ const executeUploadUiExtensions = async (environment) => {
     specificExtensions = environment.extraArgs.filter(arg => !arg.startsWith('--'));
   }
 
-  await uploadUiExtensions(uiExtensionsDir, specificExtensions);
+  await uploadUiExtensionsLib.uploadUiExtensions(uiExtensionsDir, specificExtensions);
 };
 
-module.exports = executeUploadUiExtensions;
+module.exports = {
+  requiresInstance: true,
+  execute: executeUploadUiExtensions
+};

--- a/src/lib/project-paths.js
+++ b/src/lib/project-paths.js
@@ -11,4 +11,5 @@ module.exports = {
   RESOURCE_CONFIG_PATH: 'resources.json',
   RESOURCES_DIR_PATH: 'resources',
   EXTENSION_LIBS_PATH: 'extension-libs',
+  UI_EXTENSIONS_PATH: 'ui-extensions',
 };

--- a/src/lib/upload-ui-extensions.js
+++ b/src/lib/upload-ui-extensions.js
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const path = require('path');
+const Joi = require('joi');
+const environment = require('./environment');
+const log = require('./log');
+const insertOrReplace = require('./insert-or-replace');
+const warnUploadOverwrite = require('./warn-upload-overwrite');
+const pouch = require('./db');
+
+const schema = Joi.object({
+  type: Joi.string().valid('app_main_tab', 'app_drawer_tab').required(),
+  title: Joi.string().required(),
+  icon: Joi.string().required(),
+  roles: Joi.array().items(Joi.string()),
+  config: Joi.object().unknown(true)
+});
+
+module.exports = async (uiExtensionsDir, specificExtensions = []) => {
+  if (!fs.existsSync(uiExtensionsDir)) {
+    log.info(`No directory found at "${uiExtensionsDir}" - not uploading ui-extensions`);
+    return;
+  }
+
+  const allFiles = fs.readdirSync(uiExtensionsDir);
+
+  // Extract unique extension names from either .js or .properties.json files
+  const extensionNames = new Set(
+    allFiles
+      .filter(f => f.endsWith('.js') || f.endsWith('.properties.json'))
+      .map(f => f.replace(/\.properties\.json$|\.js$/, ''))
+  );
+
+  let namesToUpload = Array.from(extensionNames);
+  if (specificExtensions && specificExtensions.length > 0) {
+    namesToUpload = namesToUpload.filter(name => specificExtensions.includes(name));
+  }
+
+  if (namesToUpload.length === 0) {
+    log.info('No UI extensions to upload.');
+    return;
+  }
+
+  log.info(`Found UI extensions: ${namesToUpload.join(', ')}`);
+
+  let db;
+
+  for (const name of namesToUpload) {
+    const jsPath = path.join(uiExtensionsDir, `${name}.js`);
+    const propsPath = path.join(uiExtensionsDir, `${name}.properties.json`);
+
+    if (!fs.existsSync(jsPath) || !fs.existsSync(propsPath)) {
+      throw new Error(`UI Extension "${name}" is missing either its .js or .properties.json file.`);
+    }
+
+    const propsContent = JSON.parse(fs.readFileSync(propsPath, 'utf-8'));
+    const validation = schema.validate(propsContent);
+
+    if (validation.error) {
+      throw new Error(`Validation error for UI extension "${name}": ${validation.error.message}`);
+    }
+
+    const jsContent = fs.readFileSync(jsPath);
+
+    const doc = {
+      _id: `ui-extension:${name}`,
+      type: 'ui-extension',
+      ...propsContent,
+      _attachments: {
+        'extension.js': {
+          content_type: 'application/javascript',
+          data: jsContent
+        }
+      }
+    };
+
+    if (!db) {
+      db = pouch(environment.apiUrl);
+    }
+
+    const changes = await warnUploadOverwrite.preUploadDoc(db, doc);
+    if (!changes) {
+      log.info(`UI Extension "${name}" not uploaded as already up to date`);
+      continue;
+    }
+
+    await insertOrReplace(db, doc);
+    log.info(`UI Extension "${name}" upload complete`);
+    await warnUploadOverwrite.postUploadDoc(db, doc);
+  }
+};

--- a/src/lib/upload-ui-extensions.js
+++ b/src/lib/upload-ui-extensions.js
@@ -57,7 +57,7 @@ const getExtensionDoc = (uiExtensionsDir, name) => {
     const rawProps = fs.readFileSync(propsPath, 'utf-8');
     propsContent = JSON.parse(rawProps);
   } catch (err) {
-    throw new Error(`Failed to parse ${name}.properties.json - Invalid JSON format.`);
+    throw new Error(`Failed to parse ${name}.properties.json - Invalid JSON format: ${err.message}`);
   }
 
   const validation = schema.validate(propsContent);

--- a/src/lib/upload-ui-extensions.js
+++ b/src/lib/upload-ui-extensions.js
@@ -15,27 +15,70 @@ const schema = Joi.object({
   config: Joi.object().unknown(true)
 });
 
-module.exports = async (uiExtensionsDir, specificExtensions = []) => {
-  if (!fs.existsSync(uiExtensionsDir)) {
-    log.info(`No directory found at "${uiExtensionsDir}" - not uploading ui-extensions`);
-    return;
-  }
-
+const getNamesToUpload = (uiExtensionsDir, specificExtensions) => {
   const allFiles = fs.readdirSync(uiExtensionsDir);
-
-  // Extract unique extension names from either .js or .properties.json files
   const extensionNames = new Set(
     allFiles
       .filter(f => f.endsWith('.js') || f.endsWith('.properties.json'))
       .map(f => f.replace(/\.properties\.json$|\.js$/, ''))
   );
 
-  let namesToUpload = Array.from(extensionNames);
-  if (specificExtensions && specificExtensions.length > 0) {
-    namesToUpload = namesToUpload.filter(name => specificExtensions.includes(name));
+  let names = Array.from(extensionNames);
+  if (specificExtensions?.length) {
+    names = names.filter(name => specificExtensions.includes(name));
+  }
+  return names;
+};
+
+const getExtensionDoc = (uiExtensionsDir, name) => {
+  const jsPath = path.join(uiExtensionsDir, `${name}.js`);
+  const propsPath = path.join(uiExtensionsDir, `${name}.properties.json`);
+
+  if (!fs.existsSync(jsPath) || !fs.existsSync(propsPath)) {
+    throw new Error(`UI Extension "${name}" is missing either its .js or .properties.json file.`);
   }
 
-  if (namesToUpload.length === 0) {
+  const propsContent = JSON.parse(fs.readFileSync(propsPath, 'utf-8'));
+  const validation = schema.validate(propsContent);
+
+  if (validation.error) {
+    throw new Error(`Validation error for UI extension "${name}": ${validation.error.message}`);
+  }
+
+  return {
+    _id: `ui-extension:${name}`,
+    type: 'ui-extension',
+    ...propsContent,
+    _attachments: {
+      'extension.js': {
+        content_type: 'application/javascript',
+        data: fs.readFileSync(jsPath)
+      }
+    }
+  };
+};
+
+const uploadDocToDb = async (db, doc, name) => {
+  const changes = await warnUploadOverwrite.preUploadDoc(db, doc);
+  if (!changes) {
+    log.info(`UI Extension "${name}" not uploaded as already up to date`);
+    return;
+  }
+
+  await insertOrReplace(db, doc);
+  log.info(`UI Extension "${name}" upload complete`);
+  await warnUploadOverwrite.postUploadDoc(db, doc);
+};
+
+const uploadUiExtensions = async (uiExtensionsDir, specificExtensions = []) => {
+  if (!fs.existsSync(uiExtensionsDir)) {
+    log.info(`No directory found at "${uiExtensionsDir}" - not uploading ui-extensions`);
+    return;
+  }
+
+  const namesToUpload = getNamesToUpload(uiExtensionsDir, specificExtensions);
+
+  if (!namesToUpload.length) {
     log.info('No UI extensions to upload.');
     return;
   }
@@ -43,48 +86,11 @@ module.exports = async (uiExtensionsDir, specificExtensions = []) => {
   log.info(`Found UI extensions: ${namesToUpload.join(', ')}`);
 
   let db;
-
   for (const name of namesToUpload) {
-    const jsPath = path.join(uiExtensionsDir, `${name}.js`);
-    const propsPath = path.join(uiExtensionsDir, `${name}.properties.json`);
-
-    if (!fs.existsSync(jsPath) || !fs.existsSync(propsPath)) {
-      throw new Error(`UI Extension "${name}" is missing either its .js or .properties.json file.`);
-    }
-
-    const propsContent = JSON.parse(fs.readFileSync(propsPath, 'utf-8'));
-    const validation = schema.validate(propsContent);
-
-    if (validation.error) {
-      throw new Error(`Validation error for UI extension "${name}": ${validation.error.message}`);
-    }
-
-    const jsContent = fs.readFileSync(jsPath);
-
-    const doc = {
-      _id: `ui-extension:${name}`,
-      type: 'ui-extension',
-      ...propsContent,
-      _attachments: {
-        'extension.js': {
-          content_type: 'application/javascript',
-          data: jsContent
-        }
-      }
-    };
-
-    if (!db) {
-      db = pouch(environment.apiUrl);
-    }
-
-    const changes = await warnUploadOverwrite.preUploadDoc(db, doc);
-    if (!changes) {
-      log.info(`UI Extension "${name}" not uploaded as already up to date`);
-      continue;
-    }
-
-    await insertOrReplace(db, doc);
-    log.info(`UI Extension "${name}" upload complete`);
-    await warnUploadOverwrite.postUploadDoc(db, doc);
+    const doc = getExtensionDoc(uiExtensionsDir, name);
+    db = db || pouch(environment.apiUrl);
+    await uploadDocToDb(db, doc, name);
   }
 };
+
+module.exports = uploadUiExtensions;

--- a/src/lib/upload-ui-extensions.js
+++ b/src/lib/upload-ui-extensions.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const Joi = require('joi');
 const environment = require('./environment');
 const log = require('./log');

--- a/src/lib/upload-ui-extensions.js
+++ b/src/lib/upload-ui-extensions.js
@@ -36,6 +36,17 @@ const getNamesToUpload = (uiExtensionsDir) => {
   return Array.from(extensionNames);
 };
 
+const readPropertiesFile = (propsPath) => {
+  try {
+    const rawProps = fs.readFileSync(propsPath, 'utf-8');
+    return JSON.parse(rawProps);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse ${propsPath.split('/').at(-1)} - Invalid JSON format: ${err.message}`
+    );
+  }
+};
+
 const getExtensionDoc = (uiExtensionsDir, name) => {
   if (!validateExtensionName(name)) {
     throw new Error(
@@ -52,13 +63,7 @@ const getExtensionDoc = (uiExtensionsDir, name) => {
     throw new Error(`UI Extension "${name}" is missing either its .js or .properties.json file.`);
   }
 
-  let propsContent;
-  try {
-    const rawProps = fs.readFileSync(propsPath, 'utf-8');
-    propsContent = JSON.parse(rawProps);
-  } catch (err) {
-    throw new Error(`Failed to parse ${name}.properties.json - Invalid JSON format: ${err.message}`);
-  }
+  const propsContent = readPropertiesFile(propsPath);
 
   const validation = schema.validate(propsContent);
   if (validation.error) {

--- a/src/lib/upload-ui-extensions.js
+++ b/src/lib/upload-ui-extensions.js
@@ -6,6 +6,7 @@ const log = require('./log');
 const insertOrReplace = require('./insert-or-replace');
 const warnUploadOverwrite = require('./warn-upload-overwrite');
 const pouch = require('./db');
+const attachmentFromFile = require('./attachment-from-file');
 
 const schema = Joi.object({
   type: Joi.string().valid('app_main_tab', 'app_drawer_tab').required(),
@@ -15,22 +16,35 @@ const schema = Joi.object({
   config: Joi.object().unknown(true)
 });
 
-const getNamesToUpload = (uiExtensionsDir, specificExtensions) => {
+//validates the name against custom web component standards
+const validateExtensionName = (name) => {
+  const startsWithLowercase = /^[a-z]/.test(name);
+  const hasHyphen = name.includes('-');
+  const hasValidChars = /^[a-z0-9_.-]+$/.test(name);
+
+  return startsWithLowercase && hasHyphen && hasValidChars;
+};
+
+const getNamesToUpload = (uiExtensionsDir) => {
   const allFiles = fs.readdirSync(uiExtensionsDir);
   const extensionNames = new Set(
     allFiles
       .filter(f => f.endsWith('.js') || f.endsWith('.properties.json'))
-      .map(f => f.replace(/\.properties\.json$|\.js$/, ''))
+      .map(f => f.replace(/(\.properties\.json|\.js)$/, ''))
   );
 
-  let names = Array.from(extensionNames);
-  if (specificExtensions?.length) {
-    names = names.filter(name => specificExtensions.includes(name));
-  }
-  return names;
+  return Array.from(extensionNames);
 };
 
 const getExtensionDoc = (uiExtensionsDir, name) => {
+  if (!validateExtensionName(name)) {
+    throw new Error(
+      `UI Extension name "${name}" is invalid. It must start with a lowercase letter, ` +
+      'contain at least one hyphen, and use only lowercase letters, digits, hyphens, ' +
+      'periods, or underscores.'
+    );
+  }
+
   const jsPath = path.join(uiExtensionsDir, `${name}.js`);
   const propsPath = path.join(uiExtensionsDir, `${name}.properties.json`);
 
@@ -38,9 +52,15 @@ const getExtensionDoc = (uiExtensionsDir, name) => {
     throw new Error(`UI Extension "${name}" is missing either its .js or .properties.json file.`);
   }
 
-  const propsContent = JSON.parse(fs.readFileSync(propsPath, 'utf-8'));
-  const validation = schema.validate(propsContent);
+  let propsContent;
+  try {
+    const rawProps = fs.readFileSync(propsPath, 'utf-8');
+    propsContent = JSON.parse(rawProps);
+  } catch (err) {
+    throw new Error(`Failed to parse ${name}.properties.json - Invalid JSON format.`);
+  }
 
+  const validation = schema.validate(propsContent);
   if (validation.error) {
     throw new Error(`Validation error for UI extension "${name}": ${validation.error.message}`);
   }
@@ -50,10 +70,7 @@ const getExtensionDoc = (uiExtensionsDir, name) => {
     type: 'ui-extension',
     ...propsContent,
     _attachments: {
-      'extension.js': {
-        content_type: 'application/javascript',
-        data: fs.readFileSync(jsPath)
-      }
+      'extension.js': attachmentFromFile(jsPath)
     }
   };
 };
@@ -76,7 +93,9 @@ const uploadUiExtensions = async (uiExtensionsDir, specificExtensions = []) => {
     return;
   }
 
-  const namesToUpload = getNamesToUpload(uiExtensionsDir, specificExtensions);
+  // if specific extensions are provided, bypass directory reading
+  // missing files will be caught by getExtensionDoc
+  const namesToUpload = specificExtensions.length ? specificExtensions : getNamesToUpload(uiExtensionsDir);
 
   if (!namesToUpload.length) {
     log.info('No UI extensions to upload.');
@@ -85,12 +104,14 @@ const uploadUiExtensions = async (uiExtensionsDir, specificExtensions = []) => {
 
   log.info(`Found UI extensions: ${namesToUpload.join(', ')}`);
 
-  let db;
-  for (const name of namesToUpload) {
-    const doc = getExtensionDoc(uiExtensionsDir, name);
-    db = db || pouch(environment.apiUrl);
+  // process all docs before uploading any to ensure validation passes for everything
+  const namesWithDocs = namesToUpload.map(name => [name, getExtensionDoc(uiExtensionsDir, name)]);
+
+  const db = pouch(environment.apiUrl);
+
+  for (const [name, doc] of namesWithDocs) {
     await uploadDocToDb(db, doc, name);
   }
 };
 
-module.exports = uploadUiExtensions;
+module.exports = { uploadUiExtensions };

--- a/test/fn/upload-ui-extensions.spec.js
+++ b/test/fn/upload-ui-extensions.spec.js
@@ -1,0 +1,53 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const environment = require('../../src/lib/environment');
+const uploadUiExtensionsLib = require('../../src/lib/upload-ui-extensions');
+const uploadUiExtensions = require('../../src/fn/upload-ui-extensions');
+
+describe('Upload UI Extensions', () => {
+  let uploadUiExtensionsStub;
+
+  beforeEach(() => {
+    uploadUiExtensionsStub = sinon.stub(uploadUiExtensionsLib, 'uploadUiExtensions').resolves();
+    sinon.stub(environment, 'pathToProject').get(() => '/testpath');
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('calls uploadUiExtensions with the ui-extensions directory and no specific extensions', async () => {
+    sinon.stub(environment, 'extraArgs').get(() => undefined);
+
+    await uploadUiExtensions.execute();
+    expect(uploadUiExtensions.requiresInstance).to.equal(true);
+
+    expect(uploadUiExtensionsStub).to.have.been.calledOnceWithExactly('/testpath/ui-extensions', []);
+  });
+
+  it('should pass specific extensions from extraArgs, filtering out flags', async () => {
+    sinon.stub(environment, 'extraArgs').get(() => ['--', 'my-extension', '--force', 'other-extension']);
+
+    await uploadUiExtensions.execute();
+
+    expect(uploadUiExtensionsStub).to.have.been.calledOnceWithExactly(
+      '/testpath/ui-extensions',
+      ['my-extension', 'other-extension']
+    );
+  });
+
+  it('should pass an empty array when extraArgs is empty', async () => {
+    sinon.stub(environment, 'extraArgs').get(() => []);
+
+    await uploadUiExtensions.execute();
+
+    expect(uploadUiExtensionsStub).to.have.been.calledOnceWithExactly('/testpath/ui-extensions', []);
+  });
+
+  it('should pass an empty array when extraArgs contains only flags', async () => {
+    sinon.stub(environment, 'extraArgs').get(() => ['--', '--force', '--debug']);
+
+    await uploadUiExtensions.execute();
+
+    expect(uploadUiExtensionsStub).to.have.been.calledOnceWithExactly('/testpath/ui-extensions', []);
+  });
+});

--- a/test/lib/upload-ui-extensions.spec.js
+++ b/test/lib/upload-ui-extensions.spec.js
@@ -1,82 +1,181 @@
-const chai = require('chai');
+const { expect } = require('chai');
 const sinon = require('sinon');
+const rewire = require('rewire');
 const fs = require('node:fs');
-
-const { uploadUiExtensions } = require('../../src/lib/upload-ui-extensions');
 const log = require('../../src/lib/log');
-
-const expect = chai.expect;
-chai.use(require('chai-as-promised'));
+const environment = require('../../src/lib/environment');
+const warnUploadOverwrite = require('../../src/lib/warn-upload-overwrite');
 
 describe('Upload UI Extensions Library', () => {
-  let sandbox;
+  let uploadUiExtensionsModule;
+  let uploadUiExtensions;
+  let pouch;
+  let insertOrReplace;
+  let attachmentFromFile;
+  let db;
+
+  const validProps = {
+    type: 'app_main_tab',
+    title: 'My Extension',
+    icon: 'star',
+    roles: ['admin'],
+    config: { foo: 'bar' }
+  };
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(log, 'info');
+    sinon.stub(log, 'info');
+    sinon.stub(environment, 'apiUrl').get(() => 'http://localhost/medic');
+    sinon.stub(warnUploadOverwrite, 'preUploadDoc');
+    sinon.stub(warnUploadOverwrite, 'postUploadDoc').resolves();
+    sinon.stub(fs, 'existsSync').returns(true);
+    sinon.stub(fs, 'readdirSync');
+
+    uploadUiExtensionsModule = rewire('../../src/lib/upload-ui-extensions');
+    uploadUiExtensions = uploadUiExtensionsModule.uploadUiExtensions;
+
+    db = { fake: 'db' };
+    pouch = sinon.stub().returns(db);
+    insertOrReplace = sinon.stub().resolves();
+    attachmentFromFile = sinon.stub().returns({ content_type: 'application/javascript', data: Buffer.from('js') });
+
+    uploadUiExtensionsModule.__set__('pouch', pouch);
+    uploadUiExtensionsModule.__set__('insertOrReplace', insertOrReplace);
+    uploadUiExtensionsModule.__set__('attachmentFromFile', attachmentFromFile);
   });
 
-  afterEach(() => {
-    sandbox.restore();
-  });
+  afterEach(() => sinon.restore());
 
-  it('should log and return if the ui-extensions directory does not exist', async () => {
-    sandbox.stub(fs, 'existsSync').returns(false);
+  it('logs a message when the ui-extensions directory does not exist', async () => {
+    fs.existsSync.returns(false);
 
     await uploadUiExtensions('/fake/path');
 
-    expect(log.info.callCount).to.equal(1);
-    expect(log.info.args[0][0]).to.include('No directory found at "/fake/path"');
+    expect(log.info).to.have.been.calledOnceWithExactly(
+      'No directory found at "/fake/path" - not uploading ui-extensions'
+    );
+    expect(pouch.called).to.be.false;
   });
 
-  it('should log and return if no valid extension files are found', async () => {
-    sandbox.stub(fs, 'existsSync').returns(true);
-    sandbox.stub(fs, 'readdirSync').returns(['random-file.txt', 'image.png']);
+  it('logs a message when no valid extension files are found', async () => {
+    fs.readdirSync.returns(['random-file.txt', 'image.png']);
 
     await uploadUiExtensions('/fake/path');
 
-    expect(log.info.callCount).to.equal(1);
-    expect(log.info.args[0][0]).to.equal('No UI extensions to upload.');
+    expect(log.info).to.have.been.calledOnceWithExactly('No UI extensions to upload.');
+    expect(pouch.called).to.be.false;
   });
 
-  it('should throw an error if an extension name does not match custom element standards', async () => {
-    sandbox.stub(fs, 'existsSync').returns(true);
-    // "myExtension" is invalid (has uppercase, no hyphen)
-    sandbox.stub(fs, 'readdirSync').returns(['myExtension.js', 'myExtension.properties.json']);
+  [
+    'myExtension',
+    'myextension',
+    'my$ext',
+  ].forEach(invalidName => {
+    it('throws an exception when the extension name is invalid', async () => {
+      fs.readdirSync.returns([`${invalidName}.js`, `${invalidName}.properties.json`]);
 
-    await expect(uploadUiExtensions('/fake/path'))
-      .to.be.rejectedWith('UI Extension name "myExtension" is invalid.');
+      await expect(uploadUiExtensions('/fake/path'))
+        .to.be.rejectedWith(`UI Extension name "${invalidName}" is invalid.`);
+    });
   });
 
-  it('should throw an error if missing either the .js or .properties.json file', async () => {
-    sandbox.stub(fs, 'readdirSync').returns(['valid-name.js']);
-
-    sandbox.stub(fs, 'existsSync').callsFake((path) => !path.includes('.properties.json'));
+  it('throws an exception if the .properties.json file is missing', async () => {
+    fs.readdirSync.returns(['valid-name.js']);
+    fs.existsSync.callsFake((p) => !p.endsWith('.properties.json'));
 
     await expect(uploadUiExtensions('/fake/path'))
       .to.be.rejectedWith('UI Extension "valid-name" is missing either its .js or .properties.json file.');
   });
 
-  it('should throw an error if properties.json is invalid JSON', async () => {
-    sandbox.stub(fs, 'existsSync').returns(true);
-    sandbox.stub(fs, 'readdirSync').returns(['valid-name.js', 'valid-name.properties.json']);
+  it('throws an exception if the .js file is missing', async () => {
+    fs.readdirSync.returns(['valid-name.properties.json']);
+    fs.existsSync.callsFake((p) => !p.endsWith('.js') || p === '/fake/path');
 
-    // simulates a broken JSON file
-    sandbox.stub(fs, 'readFileSync').returns('invalid json { oops');
+    await expect(uploadUiExtensions('/fake/path'))
+      .to.be.rejectedWith('UI Extension "valid-name" is missing either its .js or .properties.json file.');
+  });
+
+  it('throws an exception if properties.json is invalid JSON', async () => {
+    fs.readdirSync.returns(['valid-name.js', 'valid-name.properties.json']);
+    sinon.stub(fs, 'readFileSync').returns('invalid json { oops');
 
     await expect(uploadUiExtensions('/fake/path'))
       .to.be.rejectedWith('Failed to parse valid-name.properties.json - Invalid JSON format:');
   });
 
-  it('should throw an error if properties.json fails Joi schema validation', async () => {
-    sandbox.stub(fs, 'existsSync').returns(true);
-    sandbox.stub(fs, 'readdirSync').returns(['valid-name.js', 'valid-name.properties.json']);
-    
-    // missing required fields like 'icon' and 'config'
-    const invalidProps = { type: 'app_main_tab', title: 'My Extension' };
-    sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(invalidProps));
+  [
+    { type: 'app_main_tab', title: 'My Extension' },
+    { type: 'app_main_tab', icon: 'my-icon' },
+    { title: 'My Extension', icon: 'my-icon' },
+    { type: 'app_main_tab', title: 'My Extension', icon: 'my-icon', roles: 'my-role' },
+    { type: 'app_main_tab', title: 'My Extension', icon: 'my-icon', roles: ['my-role'], config: 'my-config' },
+  ].forEach(invalidProps => {
+    it('throws an exception if properties.json fails Joi schema validation', async () => {
+      fs.readdirSync.returns(['valid-name.js', 'valid-name.properties.json']);
 
-    await expect(uploadUiExtensions('/fake/path'))
-      .to.be.rejectedWith('Validation error for UI extension "valid-name":');
+      sinon.stub(fs, 'readFileSync').returns(JSON.stringify(invalidProps));
+
+      await expect(uploadUiExtensions('/fake/path'))
+        .to.be.rejectedWith('Validation error for UI extension "valid-name":');
+    });
+  });
+
+  it('uploads extension when remote differs', async () => {
+    fs.readdirSync.returns(['valid-name.js', 'valid-name.properties.json']);
+    sinon.stub(fs, 'readFileSync').returns(JSON.stringify(validProps));
+    warnUploadOverwrite.preUploadDoc.resolves(true);
+
+    await uploadUiExtensions('/fake/path');
+
+    expect(pouch).to.have.been.calledOnceWithExactly('http://localhost/medic');
+    expect(warnUploadOverwrite.preUploadDoc.callCount).to.equal(1);
+    expect(insertOrReplace.callCount).to.equal(1);
+    expect(insertOrReplace.args[0][0]).to.equal(db);
+    expect(insertOrReplace.args[0][1]).to.deep.include({
+      _id: 'ui-extension:valid-name',
+      type: 'app_main_tab',
+      title: 'My Extension',
+      icon: 'star',
+    });
+    expect(insertOrReplace.args[0][1]._attachments).to.have.property('extension.js');
+    expect(attachmentFromFile.calledOnce).to.be.true;
+    expect(warnUploadOverwrite.postUploadDoc.callCount).to.equal(1);
+    expect(log.info.args).to.deep.equal([
+      ['Found UI extensions: valid-name'],
+      ['UI Extension "valid-name" upload complete'],
+    ]);
+  });
+
+  it('skips upload when doc matches remote', async () => {
+    fs.readdirSync.returns(['valid-name.js', 'valid-name.properties.json']);
+    sinon.stub(fs, 'readFileSync').returns(JSON.stringify(validProps));
+    warnUploadOverwrite.preUploadDoc.resolves(false);
+
+    await uploadUiExtensions('/fake/path');
+
+    expect(warnUploadOverwrite.preUploadDoc.callCount).to.equal(1);
+    expect(insertOrReplace.called).to.be.false;
+    expect(warnUploadOverwrite.postUploadDoc.called).to.be.false;
+    expect(log.info.args).to.deep.equal([
+      ['Found UI extensions: valid-name'],
+      ['UI Extension "valid-name" not uploaded as already up to date'],
+    ]);
+  });
+
+  it('bypasses directory reading when specific extensions are provided', async () => {
+    sinon.stub(fs, 'readFileSync').returns(JSON.stringify(validProps));
+    warnUploadOverwrite.preUploadDoc.resolves(true);
+
+    await uploadUiExtensions('/fake/path', ['only-this-one']);
+
+    expect(fs.readdirSync.called).to.be.false;
+    expect(insertOrReplace.callCount).to.equal(1);
+    expect(insertOrReplace.args[0][1]._id).to.equal('ui-extension:only-this-one');
+  });
+
+  it('should throw for a specific extension whose files do not exist', async () => {
+    fs.existsSync.callsFake((p) => p === '/fake/path');
+
+    await expect(uploadUiExtensions('/fake/path', ['missing-ext']))
+      .to.be.rejectedWith('UI Extension "missing-ext" is missing either its .js or .properties.json file.');
   });
 });

--- a/test/lib/upload-ui-extensions.spec.js
+++ b/test/lib/upload-ui-extensions.spec.js
@@ -1,10 +1,12 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const fs = require('node:fs');
-const uploadUiExtensions = require('../../src/lib/upload-ui-extensions');
+
+const { uploadUiExtensions } = require('../../src/lib/upload-ui-extensions');
 const log = require('../../src/lib/log');
 
 const expect = chai.expect;
+chai.use(require('chai-as-promised'));
 
 describe('Upload UI Extensions Library', () => {
   let sandbox;
@@ -35,5 +37,49 @@ describe('Upload UI Extensions Library', () => {
 
     expect(log.info.callCount).to.equal(1);
     expect(log.info.args[0][0]).to.equal('No UI extensions to upload.');
+  });
+
+  it('should throw an error if an extension name does not match custom element standards', async () => {
+    sandbox.stub(fs, 'existsSync').returns(true);
+    // "myExtension" is invalid (has uppercase, no hyphen)
+    sandbox.stub(fs, 'readdirSync').returns(['myExtension.js', 'myExtension.properties.json']);
+
+    await expect(uploadUiExtensions('/fake/path'))
+      .to.be.rejectedWith('UI Extension name "myExtension" is invalid.');
+  });
+
+  it('should throw an error if missing either the .js or .properties.json file', async () => {
+    sandbox.stub(fs, 'readdirSync').returns(['valid-name.js']);
+    
+    sandbox.stub(fs, 'existsSync').callsFake((path) => {
+      if (path.includes('.properties.json')) {return false;}
+      return true;
+    });
+
+    await expect(uploadUiExtensions('/fake/path'))
+      .to.be.rejectedWith('UI Extension "valid-name" is missing either its .js or .properties.json file.');
+  });
+
+  it('should throw an error if properties.json is invalid JSON', async () => {
+    sandbox.stub(fs, 'existsSync').returns(true);
+    sandbox.stub(fs, 'readdirSync').returns(['valid-name.js', 'valid-name.properties.json']);
+    
+    // simulates a broken JSON file
+    sandbox.stub(fs, 'readFileSync').returns('invalid json { oops');
+
+    await expect(uploadUiExtensions('/fake/path'))
+      .to.be.rejectedWith('Failed to parse valid-name.properties.json - Invalid JSON format.');
+  });
+
+  it('should throw an error if properties.json fails Joi schema validation', async () => {
+    sandbox.stub(fs, 'existsSync').returns(true);
+    sandbox.stub(fs, 'readdirSync').returns(['valid-name.js', 'valid-name.properties.json']);
+    
+    // missing required fields like 'icon' and 'config'
+    const invalidProps = { type: 'app_main_tab', title: 'My Extension' };
+    sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(invalidProps));
+
+    await expect(uploadUiExtensions('/fake/path'))
+      .to.be.rejectedWith('Validation error for UI extension "valid-name":');
   });
 });

--- a/test/lib/upload-ui-extensions.spec.js
+++ b/test/lib/upload-ui-extensions.spec.js
@@ -50,11 +50,8 @@ describe('Upload UI Extensions Library', () => {
 
   it('should throw an error if missing either the .js or .properties.json file', async () => {
     sandbox.stub(fs, 'readdirSync').returns(['valid-name.js']);
-    
-    sandbox.stub(fs, 'existsSync').callsFake((path) => {
-      if (path.includes('.properties.json')) {return false;}
-      return true;
-    });
+
+    sandbox.stub(fs, 'existsSync').callsFake((path) => !path.includes('.properties.json'));
 
     await expect(uploadUiExtensions('/fake/path'))
       .to.be.rejectedWith('UI Extension "valid-name" is missing either its .js or .properties.json file.');
@@ -63,12 +60,12 @@ describe('Upload UI Extensions Library', () => {
   it('should throw an error if properties.json is invalid JSON', async () => {
     sandbox.stub(fs, 'existsSync').returns(true);
     sandbox.stub(fs, 'readdirSync').returns(['valid-name.js', 'valid-name.properties.json']);
-    
+
     // simulates a broken JSON file
     sandbox.stub(fs, 'readFileSync').returns('invalid json { oops');
 
     await expect(uploadUiExtensions('/fake/path'))
-      .to.be.rejectedWith('Failed to parse valid-name.properties.json - Invalid JSON format.');
+      .to.be.rejectedWith('Failed to parse valid-name.properties.json - Invalid JSON format:');
   });
 
   it('should throw an error if properties.json fails Joi schema validation', async () => {

--- a/test/lib/upload-ui-extensions.spec.js
+++ b/test/lib/upload-ui-extensions.spec.js
@@ -1,0 +1,39 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const fs = require('fs');
+const uploadUiExtensions = require('../../src/lib/upload-ui-extensions');
+const log = require('../../src/lib/log');
+
+const expect = chai.expect;
+
+describe('Upload UI Extensions Library', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(log, 'info');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should log and return if the ui-extensions directory does not exist', async () => {
+    sandbox.stub(fs, 'existsSync').returns(false);
+
+    await uploadUiExtensions('/fake/path');
+
+    expect(log.info.callCount).to.equal(1);
+    expect(log.info.args[0][0]).to.include('No directory found at "/fake/path"');
+  });
+
+  it('should log and return if no valid extension files are found', async () => {
+    sandbox.stub(fs, 'existsSync').returns(true);
+    sandbox.stub(fs, 'readdirSync').returns(['random-file.txt', 'image.png']);
+
+    await uploadUiExtensions('/fake/path');
+
+    expect(log.info.callCount).to.equal(1);
+    expect(log.info.args[0][0]).to.equal('No UI extensions to upload.');
+  });
+});

--- a/test/lib/upload-ui-extensions.spec.js
+++ b/test/lib/upload-ui-extensions.spec.js
@@ -1,6 +1,6 @@
 const chai = require('chai');
 const sinon = require('sinon');
-const fs = require('fs');
+const fs = require('node:fs');
 const uploadUiExtensions = require('../../src/lib/upload-ui-extensions');
 const log = require('../../src/lib/log');
 


### PR DESCRIPTION
# Description
Fixes #792 
Added a new `upload-ui-extensions` action to the CLI. UI extensions require both a `.js` and `.properties.json` file. 

This action reads the `ui-extensions` directory, validates the `.properties.json` via Joi (ensuring `type` is either `app_main_tab` or `app_drawer_tab`, and checking types for `title`, `icon`, `roles`, and `config`), and pushes them to the `medic` database under the `ui-extension:${fileName}` ID. The `.js` file is stored as an attachment. It also supports targeted uploads (e.g., `cht upload-ui-extensions -- delivery`) utilizing `environment.extraArgs`.

The core logic has been extracted into `src/lib/upload-ui-extensions.js` for better code management, and unit tests have been included to verify directory and file parsing behavior.

*Note: I am currently familiarizing myself with the codebase conventions and commenting styles. Please let me know if there are any suggestions or improvements I can make regarding my code style!*

medic/cht-conf #792 

# Code review items

- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or integration tests where appropriate
- [x] Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.