### PR TITLE
feat(#10240): allow limit_count_to_goal in target configuration schema

### DIFF
--- a/src/lib/compilation/validate-declarative-schema.js
+++ b/src/lib/compilation/validate-declarative-schema.js
@@ -82,6 +82,7 @@ const TargetSchema = joi.array().items(
       .optional()
       .error(targetError('idType should be either "report" or "contact" or "function(contact, report)"')),
     aggregate: joi.boolean().optional(),
+    limit_count_to_goal: joi.boolean().optional(),
   })
 )
   .unique('id')

--- a/src/lib/parse-targets.js
+++ b/src/lib/parse-targets.js
@@ -51,6 +51,7 @@ module.exports = projectDir => {
       'dhis',
       'visible',
       'aggregate',
+      'limit_count_to_goal',
     ])),
   };
 };


### PR DESCRIPTION
Add `limit_count_to_goal` as an optional boolean field to the Joi schema for declarative targets, matching the new field added in cht-core that caps the displayed count at the goal value.

<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Adds `limit_count_to_goal` as an optional boolean field to the declarative target Joi validation schema, and includes it in the compiled target output.

This is a companion to medic/cht-core#10772, which introduces the `limit_count_to_goal` field to cht-core. The underlying issue is tracked in cht-core as medic/cht-core#10240.

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# AI Disclosure

Claude Code was used to locate the correct place in the schema, add the field, and run the test suite to verify nothing was broken.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
