### PR TITLE
chore: update config to not run Google tests on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
       GOOGLE_REDIRECT_URI: "http://localhost"
       GOOGLE_TOKEN_SCOPE: 'https://www.googleapis.com/auth/drive.readonly'
-      RUN_GOOGLE_TESTS: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+      RUN_GOOGLE_TESTS: ${{ secrets.GOOGLE_CREDENTIALS != '' }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
       GOOGLE_REDIRECT_URI: "http://localhost"
       GOOGLE_TOKEN_SCOPE: 'https://www.googleapis.com/auth/drive.readonly'
+      RUN_GOOGLE_TESTS: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
 
     steps:
     - uses: actions/checkout@v4
@@ -54,6 +55,7 @@ jobs:
       run: |
         echo "15.188.129.97 local-ip.medicmobile.org" | sudo tee -a /etc/hosts
     - id: auth
+      if: ${{ env.RUN_GOOGLE_TESTS == 'true' }}
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
       with:
         service_account: ${{ env.GOOGLE_SERVICE_ACCT }}
@@ -61,6 +63,7 @@ jobs:
         token_format: access_token
         access_token_scopes: ${{ env.GOOGLE_TOKEN_SCOPE }}
     - name: Write access_token to .gdrive.session.json
+      if: ${{ env.RUN_GOOGLE_TESTS == 'true' }}
       run: |
         echo '{
           "access_token": "${{ steps.auth.outputs.access_token }}",

--- a/test/e2e/.mocharc.js
+++ b/test/e2e/.mocharc.js
@@ -4,7 +4,7 @@ module.exports = {
   ...rootConfig,
   captureFile: 'test/e2e/results.txt',
   checkLeaks: true,
-  exclude: process.env.RUN_GOOGLE_TESTS ? [] : ['test/e2e/fetch-forms-from-google-drive.spec.js'], // Do not run Google tests locally by default
+  exclude: process.env.RUN_GOOGLE_TESTS === 'true' ? [] : ['test/e2e/fetch-forms-from-google-drive.spec.js'], // Do not run Google tests locally by default
   file: 'test/e2e/hooks.js',
   spec: 'test/e2e/**/*.spec.js',
   timeout: 120_000, // spinning up a CHT instance takes a little long

--- a/test/e2e/.mocharc.js
+++ b/test/e2e/.mocharc.js
@@ -4,7 +4,7 @@ module.exports = {
   ...rootConfig,
   captureFile: 'test/e2e/results.txt',
   checkLeaks: true,
-  exclude: process.env.CI ? [] : ['test/e2e/fetch-forms-from-google-drive.spec.js'], // Do not run Google tests locally by default
+  exclude: process.env.RUN_GOOGLE_TESTS ? [] : ['test/e2e/fetch-forms-from-google-drive.spec.js'], // Do not run Google tests locally by default
   file: 'test/e2e/hooks.js',
   spec: 'test/e2e/**/*.spec.js',
   timeout: 120_000, // spinning up a CHT instance takes a little long


### PR DESCRIPTION
# Description

The [new Google integration tests](https://github.com/medic/cht-conf/pull/796) fail [when running on PRs from forks](https://github.com/medic/cht-conf/actions/runs/23685110710/job/69403738820?pr=798) because the fork jobs do not have access to the secrets. 

This PR just updates the CI to not run these tests in that case.

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
