### PR TITLE
feat(#807): add user-contact-summary instance to contact forms

### DIFF
--- a/src/fn/convert-contact-forms.js
+++ b/src/fn/convert-contact-forms.js
@@ -5,6 +5,7 @@ const { CONTACT_FORMS_PATH } = require('../lib/project-paths');
 
 const convertContactForm = (forms) => {
   const dir = `${environment.pathToProject}/${CONTACT_FORMS_PATH}`;
+  const userContactSummaryXML = '\n    <instance id="user-contact-summary"/>';
   const placeTypesJson = `${dir}/place-types.json`;
 
   let PLACE_TYPES;
@@ -80,7 +81,7 @@ const convertContactForm = (forms) => {
           }
         }
       }
-
+      xml = xml.replace('</instance>', `</instance>${userContactSummaryXML}`);     
       return xml;
     },
   });
@@ -92,3 +93,4 @@ module.exports = {
   CONTACT_FORMS_PATH,
   execute: () => convertContactForm(environment.extraArgs)
 };
+

--- a/test/data/convert-contact-forms/forms/contact/expected/district_hospital.xml
+++ b/test/data/convert-contact-forms/forms/contact/expected/district_hospital.xml
@@ -34,6 +34,7 @@
           </meta>
         </data>
       </instance>
+      <instance id="user-contact-summary"/>
       <instance id="yes_no">
         <root>
           <item>

--- a/test/data/convert-contact-forms/forms/contact/expected/person-edit.xml
+++ b/test/data/convert-contact-forms/forms/contact/expected/person-edit.xml
@@ -21,6 +21,7 @@
           </meta>
         </data>
       </instance>
+      <instance id="user-contact-summary"/>
       <instance id="yes_no">
         <root>
           <item>

--- a/test/data/convert-contact-forms/forms/contact/expected/person.xml
+++ b/test/data/convert-contact-forms/forms/contact/expected/person.xml
@@ -35,6 +35,7 @@
           </meta>
         </data>
       </instance>
+      <instance id="user-contact-summary"/>
       <instance id="nationality">
         <root>
           <item>

--- a/test/data/generate-contact-forms/forms/contact/expected/clinic-create.xml
+++ b/test/data/generate-contact-forms/forms/contact/expected/clinic-create.xml
@@ -1070,6 +1070,7 @@
           </meta>
         </data>
       </instance>
+      <instance id="user-contact-summary"/>
       <instance id="yes_no">
         <root>
           <item>

--- a/test/data/generate-contact-forms/forms/contact/expected/clinic-edit.xml
+++ b/test/data/generate-contact-forms/forms/contact/expected/clinic-edit.xml
@@ -877,6 +877,7 @@
           </meta>
         </data>
       </instance>
+      <instance id="user-contact-summary"/>
       <instance id="yes_no">
         <root>
           <item>

--- a/test/data/generate-contact-forms/forms/contact/expected/district_hospital-create.xml
+++ b/test/data/generate-contact-forms/forms/contact/expected/district_hospital-create.xml
@@ -1070,6 +1070,7 @@
           </meta>
         </data>
       </instance>
+      <instance id="user-contact-summary"/>
       <instance id="yes_no">
         <root>
           <item>

--- a/test/data/generate-contact-forms/forms/contact/expected/district_hospital-edit.xml
+++ b/test/data/generate-contact-forms/forms/contact/expected/district_hospital-edit.xml
@@ -877,6 +877,7 @@
           </meta>
         </data>
       </instance>
+      <instance id="user-contact-summary"/>
       <instance id="yes_no">
         <root>
           <item>

--- a/test/data/generate-contact-forms/forms/contact/expected/health_center-create.xml
+++ b/test/data/generate-contact-forms/forms/contact/expected/health_center-create.xml
@@ -1070,6 +1070,7 @@
           </meta>
         </data>
       </instance>
+      <instance id="user-contact-summary"/>
       <instance id="yes_no">
         <root>
           <item>

--- a/test/data/generate-contact-forms/forms/contact/expected/health_center-edit.xml
+++ b/test/data/generate-contact-forms/forms/contact/expected/health_center-edit.xml
@@ -877,6 +877,7 @@
           </meta>
         </data>
       </instance>
+      <instance id="user-contact-summary"/>
       <instance id="yes_no">
         <root>
           <item>


### PR DESCRIPTION
# Description

Injects `<instance id="user-contact-summary"/>` into contact form XML during conversion, for both create and edit forms. This mirrors the existing behavior for app forms added in #705.

Closes medic/cht-conf#807

# Code review items

- Readable: Concise, well named, follows the style guide
- Tested: Updated expected XML files for convert-contact-forms and generate-contact-forms tests. All tests passing 
- Backwards compatible: Additive change only, no breaking changes