### PR TITLE
chore: name scheduled task emitter test

### DIFF
--- a/test/nools/task-emitter.spec.js
+++ b/test/nools/task-emitter.spec.js
@@ -921,7 +921,7 @@ describe('task-emitter', () => {
     });
 
     describe('scheduled-task based', () => {
-      it('???', () => { // FIXME this test needs a proper name
+      it('should emit once per scheduled task in a report', () => { 
         // given
         const config = {
           c: personWithReports(aReportWithScheduledTasks(5)),


### PR DESCRIPTION
## Proposed changes
In `task-emitter.spec.js` — named the unnamed scheduled-task based test case.

**Before**
```typescript
describe('scheduled-task based', () => {
  it('???', () => { // FIXME this test needs a proper name
```
**After**
```typescript
describe('scheduled-task based', () => {
  it('should emit once per scheduled task in a report', () => {
```
## Steps to reproduce
See `test/nools/task-emitter.spec.ts`

## Testing
This is a refactor only. No functional changes were made.
