### PR TITLE
feat(#10766): support `collapsed` in contact summary card

### DIFF
--- a/src/contact-summary/contact-summary-emitter.js
+++ b/src/contact-summary/contact-summary-emitter.js
@@ -122,11 +122,14 @@ function addCard(card, context, r) {
     card.modifyContext(context, r);
   }
 
-  return {
+  const summary = {
     label: card.label,
-    collapsed: card.collapsed,
     fields: fields,
   };
+  if (card.collapsed !== undefined) {
+    summary.collapsed = card.collapsed;
+  }
+  return summary;
 }
 
 module.exports = emitter;

--- a/src/contact-summary/contact-summary-emitter.js
+++ b/src/contact-summary/contact-summary-emitter.js
@@ -124,6 +124,7 @@ function addCard(card, context, r) {
 
   return {
     label: card.label,
+    collapsed: card.collapsed,
     fields: fields,
   };
 }

--- a/test/contact-summary/contact-summary-emitter.spec.js
+++ b/test/contact-summary/contact-summary-emitter.spec.js
@@ -44,6 +44,20 @@ describe('contact-summary-emitter', function() {
       });
     });
 
+    it('includes the collapsed property on emitted cards', () => {
+      const cards = [
+        { appliesToType: 'report', fields: [], label: 'collapsed-card', collapsed: true },
+        { appliesToType: 'report', fields: [], label: 'expanded-card', collapsed: false },
+      ];
+      const report = { report: true };
+      const actual = emitter({ cards }, {}, [report]);
+
+      expect(actual.cards).to.deep.eq([
+        { fields: [], label: 'collapsed-card', collapsed: true },
+        { fields: [], label: 'expanded-card', collapsed: false },
+      ]);
+    });
+
     it('allows appliesToType to be an array', () => {
       const appliesIf = sinon.stub().returns(false);
       const cards = [


### PR DESCRIPTION
## Description
medic/cht-core#10766 (related)

Adds `collapsed: card.collapsed` to the returned object in the contact summary card emitter, so that the `collapsed` property set in app config is passed through to the webapp.

## Changes
- Include `collapsed` property in the card object returned by `addCard()` in `contact-summary-emitter.js`