### PR TITLE
feat(#771): deprecate NO_LABEL usage in forms

### DIFF
--- a/src/lib/convert-forms/handle-no-label-placeholders.js
+++ b/src/lib/convert-forms/handle-no-label-placeholders.js
@@ -1,4 +1,5 @@
 const { getNodes, removeNode, XPATH_MODEL, XPATH_BODY } = require('../forms-utils');
+const log = require('../log');
 
 module.exports = {
   /**
@@ -6,6 +7,15 @@ module.exports = {
    * convention is to use a "NO_LABEL" placeholder value.
    */
   removeNoLabelNodes: (xmlDoc) => {
+    const noLabelNodes = getNodes(xmlDoc, `${XPATH_MODEL}/itext/translation//value[text()="NO_LABEL"]`);
+    if (noLabelNodes.length > 0) {
+      log.warn(
+        'The "NO_LABEL" value is deprecated and will be removed in a future version of cht-conf. '+
+        'For groups, a label is not required. For other fields, if you set a hint you do not have to provide a label. '+
+        'If the field should not be visible, use "hidden" or "calculate" types.'
+      );
+    }
+
     const noLabelItextNodes = getNodes(
       xmlDoc,
       `${XPATH_MODEL}/itext/translation//text[count(*)=1 and (value="NO_LABEL" or value="DELETE_THIS_LINE")]`

--- a/src/lib/convert-forms/handle-no-label-placeholders.js
+++ b/src/lib/convert-forms/handle-no-label-placeholders.js
@@ -7,15 +7,6 @@ module.exports = {
    * convention is to use a "NO_LABEL" placeholder value.
    */
   removeNoLabelNodes: (xmlDoc) => {
-    const noLabelNodes = getNodes(xmlDoc, `${XPATH_MODEL}/itext/translation//value[text()="NO_LABEL"]`);
-    if (noLabelNodes.length > 0) {
-      log.warn(
-        'The "NO_LABEL" value is deprecated and will be removed in a future version of cht-conf. '+
-        'For groups, a label is not required. For other fields, if you set a hint you do not have to provide a label. '+
-        'If the field should not be visible, use "hidden" or "calculate" types.'
-      );
-    }
-
     const noLabelItextNodes = getNodes(
       xmlDoc,
       `${XPATH_MODEL}/itext/translation//text[count(*)=1 and (value="NO_LABEL" or value="DELETE_THIS_LINE")]`
@@ -27,7 +18,18 @@ module.exports = {
     noLabelItextNodes.forEach(removeNode);
 
     // Remove any additional NO_LABEL values from translation nodes that have other (multimedia) values
-    getNodes(xmlDoc, `${XPATH_MODEL}/itext/translation//value[text()="NO_LABEL" or text()="DELETE_THIS_LINE"]`)
-      .forEach(removeNode);
+    const noLabelValueNodes = getNodes(
+      xmlDoc,
+      `${XPATH_MODEL}/itext/translation//value[text()="NO_LABEL" or text()="DELETE_THIS_LINE"]`
+    );
+    noLabelValueNodes.forEach(removeNode);
+
+    if (noLabelItextNodes.length > 0 || noLabelValueNodes.length > 0) {
+      log.warn(
+        'The "NO_LABEL/DELETE_THIS_LINE" value is deprecated and will be removed in a future version of cht-conf. ' +
+        'For groups, a label is not required. For other fields, if you set a hint you do not have to provide a ' +
+        'label. If the field should not be visible, use "hidden" or "calculate" types.'
+      );
+    }
   }
 };

--- a/src/lib/convert-forms/handle-no-label-placeholders.js
+++ b/src/lib/convert-forms/handle-no-label-placeholders.js
@@ -27,8 +27,7 @@ module.exports = {
     if (noLabelItextNodes.length > 0 || noLabelValueNodes.length > 0) {
       log.warn(
         'The "NO_LABEL/DELETE_THIS_LINE" value is deprecated and will be removed in a future version of cht-conf. ' +
-        'For groups, a label is not required. For other fields, if you set a hint you do not have to provide a ' +
-        'label. If the field should not be visible, use "hidden" or "calculate" types.'
+        'For groups, a label is not required. If the field should not be visible, use the "hidden" or "calculate" type.'
       );
     }
   }

--- a/test/lib/convert-forms/handle-no-label-placeholders.spec.js
+++ b/test/lib/convert-forms/handle-no-label-placeholders.spec.js
@@ -5,8 +5,8 @@ const { removeNoLabelNodes } = require('../../../src/lib/convert-forms/handle-no
 const { createXformDoc, createXformString, serializeToString } = require('../../fn/convert-forms.utils');
 
 const WARNING_TEXT = 'The "NO_LABEL/DELETE_THIS_LINE" value is deprecated and will be removed in a future version of ' +
-  'cht-conf. For groups, a label is not required. For other fields, if you set a hint you do not have to provide a ' +
-  'label. If the field should not be visible, use "hidden" or "calculate" types.';
+  'cht-conf. For groups, a label is not required. If the field should not be visible, use the "hidden" or ' +
+  '"calculate" type.';
 
 describe('Handle NO_LABEL placeholders', () => {
   beforeEach(() => {

--- a/test/lib/convert-forms/handle-no-label-placeholders.spec.js
+++ b/test/lib/convert-forms/handle-no-label-placeholders.spec.js
@@ -1,8 +1,18 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const log = require('../../../src/lib/log');
 const { removeNoLabelNodes } = require('../../../src/lib/convert-forms/handle-no-label-placeholders');
 const { createXformDoc, createXformString, serializeToString } = require('../../fn/convert-forms.utils');
 
 describe('Handle NO_LABEL placeholders', () => {
+  beforeEach(() => {
+    sinon.stub(log, 'warn');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('removes labels and itext text nodes that are only NO_LABEL', () => {
     const doc = createXformDoc({
       itext: `
@@ -34,6 +44,9 @@ describe('Handle NO_LABEL placeholders', () => {
     });
 
     removeNoLabelNodes(doc);
+
+    expect(log.warn.callCount).to.equal(1);
+    expect(log.warn.firstCall.args[0]).to.include('The "NO_LABEL" value is deprecated');
 
     const expectedDoc = createXformString({
       itext: `
@@ -76,6 +89,9 @@ describe('Handle NO_LABEL placeholders', () => {
 
     removeNoLabelNodes(doc);
 
+    expect(log.warn.callCount).to.equal(1);
+    expect(log.warn.firstCall.args[0]).to.include('The "NO_LABEL" value is deprecated');
+
     const expectedDoc = createXformDoc({
       itext: `
         <translation lang="en">
@@ -115,6 +131,9 @@ describe('Handle NO_LABEL placeholders', () => {
     });
 
     removeNoLabelNodes(doc);
+
+    expect(log.warn.callCount).to.equal(1);
+    expect(log.warn.firstCall.args[0]).to.include('The "NO_LABEL" value is deprecated');
 
     const expectedDoc = createXformDoc({
       itext: `

--- a/test/lib/convert-forms/handle-no-label-placeholders.spec.js
+++ b/test/lib/convert-forms/handle-no-label-placeholders.spec.js
@@ -4,6 +4,10 @@ const log = require('../../../src/lib/log');
 const { removeNoLabelNodes } = require('../../../src/lib/convert-forms/handle-no-label-placeholders');
 const { createXformDoc, createXformString, serializeToString } = require('../../fn/convert-forms.utils');
 
+const WARNING_TEXT = 'The "NO_LABEL/DELETE_THIS_LINE" value is deprecated and will be removed in a future version of ' +
+  'cht-conf. For groups, a label is not required. For other fields, if you set a hint you do not have to provide a ' +
+  'label. If the field should not be visible, use "hidden" or "calculate" types.';
+
 describe('Handle NO_LABEL placeholders', () => {
   beforeEach(() => {
     sinon.stub(log, 'warn');
@@ -45,9 +49,6 @@ describe('Handle NO_LABEL placeholders', () => {
 
     removeNoLabelNodes(doc);
 
-    expect(log.warn.callCount).to.equal(1);
-    expect(log.warn.firstCall.args[0]).to.include('The "NO_LABEL" value is deprecated');
-
     const expectedDoc = createXformString({
       itext: `
         <translation lang="en">
@@ -67,6 +68,7 @@ describe('Handle NO_LABEL placeholders', () => {
       `
     });
     expect(serializeToString(doc)).xml.to.equal(expectedDoc);
+    expect(log.warn).to.have.been.calledOnceWithExactly(WARNING_TEXT);
   });
 
   it('keeps label when text has other values, but removes NO_LABEL values', () => {
@@ -89,9 +91,6 @@ describe('Handle NO_LABEL placeholders', () => {
 
     removeNoLabelNodes(doc);
 
-    expect(log.warn.callCount).to.equal(1);
-    expect(log.warn.firstCall.args[0]).to.include('The "NO_LABEL" value is deprecated');
-
     const expectedDoc = createXformDoc({
       itext: `
         <translation lang="en">
@@ -107,6 +106,7 @@ describe('Handle NO_LABEL placeholders', () => {
       `
     });
     expect(serializeToString(doc)).xml.to.equal(expectedDoc);
+    expect(log.warn).to.have.been.calledOnceWithExactly(WARNING_TEXT);
   });
 
   it('handles multiple translations with NO_LABEL by removing all and associated labels', () => {
@@ -132,9 +132,6 @@ describe('Handle NO_LABEL placeholders', () => {
 
     removeNoLabelNodes(doc);
 
-    expect(log.warn.callCount).to.equal(1);
-    expect(log.warn.firstCall.args[0]).to.include('The "NO_LABEL" value is deprecated');
-
     const expectedDoc = createXformDoc({
       itext: `
         <translation lang="en" />
@@ -143,5 +140,6 @@ describe('Handle NO_LABEL placeholders', () => {
       body: `<input ref="/data/d"/>`
     });
     expect(serializeToString(doc)).xml.to.equal(expectedDoc);
+    expect(log.warn).to.have.been.calledOnceWithExactly(WARNING_TEXT);
   });
 });


### PR DESCRIPTION

# Description

This change adds a deprecation warning when the non-spec-compliant NO_LABEL value is used in form XLS configurations.

Closes #771

  - Added a check during form conversion to detect any NO_LABEL values in the generated XForm.
   - If found, it triggers a log.warn with a descriptive message explaining that the feature is deprecated and providing spec-compliant alternatives:

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
