### PR TITLE
fix(#640): correctly nest contact group when init has nested groups

### DIFF
--- a/src/fn/convert-contact-forms.js
+++ b/src/fn/convert-contact-forms.js
@@ -2,6 +2,8 @@ const convertForms = require('../lib/convert-forms').execute;
 const environment = require('../lib/environment');
 const fs = require('../lib/sync-fs');
 const { CONTACT_FORMS_PATH } = require('../lib/project-paths');
+const { DOMParser, XMLSerializer } = require('@xmldom/xmldom');
+const { removeNode } = require('../lib/forms-utils');
 
 const convertContactForm = (forms) => {
   const dir = `${environment.pathToProject}/${CONTACT_FORMS_PATH}`;
@@ -61,23 +63,18 @@ const convertContactForm = (forms) => {
       }
 
       if (xml.includes('ref="/data/contact"')) {
-        const groupRegex = name => new RegExp(`(\\s*)<group(\\s.*)?\\sref="${name}"(\\s.*)?>[^]*?</group>`);
-        let matchedBlock;
+        const domParser = new DOMParser();
+        const serializer = new XMLSerializer();
+        const doc = domParser.parseFromString(xml, 'text/xml');
 
-        if (xml.match(groupRegex('/data/init'))) {
-          xml = xml.replace(groupRegex('/data/contact'), match => {
-            matchedBlock = match;
-            return '';
-          });
+        const groups = Array.from(doc.getElementsByTagName('group'));
+        const contactGroup = groups.find(g => g.getAttribute('ref') === '/data/contact');
+        const initGroup = groups.find(g => g.getAttribute('ref') === '/data/init');
 
-          if (matchedBlock) {
-            const stripTrailingGroup = s => s.replace(/[\r\n\s]*<\/group>$/, '');
-            xml = xml.replace(groupRegex('/data/init'), match => {
-              return stripTrailingGroup(match) +
-                stripTrailingGroup(matchedBlock).replace(/\n/g, '\n  ') +
-                '\n        </group>\n      </group>';
-            });
-          }
+        if (contactGroup && initGroup) {
+          removeNode(contactGroup);
+          initGroup.appendChild(contactGroup);
+          xml = serializer.serializeToString(doc);
         }
       }
 


### PR DESCRIPTION

# Description
fixed a bug in the contact form conversion logic that was causing /data/contact groups to be nested incorrectly when the form had other nested groups.

fixes #640 

Replaced the Regular Expression based nesting logic in src/fn/convert-contact-forms.js with a DOM-based approach using DOMParser.

   1. Imports: Added DOMParser and XMLSerializer from the @xmldom/xmldom package.
   2. Logic: Instead of using a string-based search-and-replace, the code now:
       * Parses the form XML into a searchable document tree.
       * Explicitly finds the group nodes with ref="/data/contact" and ref="/data/init".
       * Moves the contact group to be a direct child at the end of the init group.

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
