### PR TITLE
fix(#10706): correct log message showing contact count in delete-hierarchy

### DIFF
--- a/src/lib/hierarchy-operations/delete-hierarchy.js
+++ b/src/lib/hierarchy-operations/delete-hierarchy.js
@@ -24,7 +24,7 @@ async function deleteHierarchy(db, options, sourceIds) {
     const affectedContactCount = descendantsAndSelf.length;
     
     info(
-      `Staged updates to delete ${prettyPrintDocument(sourceDoc)}. ${affectedContactCount.length} contact(s) `
+      `Staged updates to delete ${prettyPrintDocument(sourceDoc)}. ${affectedContactCount} contact(s) `
       + `and ${affectedReportCount} report(s).`
     );
   }


### PR DESCRIPTION
## Summary

Fixes a bug where `affectedContactCount.length` was used in a log message, but `affectedContactCount` is already a number (`descendantsAndSelf.length`). This caused the log to print `undefined contact(s)` instead of the actual count.

## Change
- Changed `${affectedContactCount.length}` to `${affectedContactCount}` in the info log line

## Related
This work is part of understanding the hierarchy operations code that DMP 2026 issue [medic/cht-core#10706](https://github.com/medic/cht-core/issues/10706) plans to port into `cht-core` as REST API endpoints.