### PR TITLE
docs: add --force flag documentation to delete-contacts, move-contacts, merge-contacts

### DIFF
--- a/src/fn/delete-contacts.js
+++ b/src/fn/delete-contacts.js
@@ -61,6 +61,9 @@ ${bold('OPTIONS')}
 
 --docDirectoryPath=<path to stage docs>
   Specifies the folder used to store the documents representing the changes in hierarchy.
+
+--force
+  Don't prompt if the doc staging folder already contains files; continue using it.
 `);
   /* eslint-enable max-len */
 };

--- a/src/fn/merge-contacts.js
+++ b/src/fn/merge-contacts.js
@@ -82,6 +82,9 @@ ${bold('OPTIONS')}
 
 --docDirectoryPath=<path to stage docs>
   Specifies the folder used to store the documents representing the changes in hierarchy.
+
+--force
+  Don't prompt if the doc staging folder already contains files; continue using it.
 `);
   /* eslint-enable max-len */
 };

--- a/src/fn/move-contacts.js
+++ b/src/fn/move-contacts.js
@@ -65,6 +65,9 @@ ${bold('OPTIONS')}
 
 --docDirectoryPath=<path to stage docs>
   Specifies the folder used to store the documents representing the changes in hierarchy.
+
+--force
+  Don't prompt if the doc staging folder already contains files; continue using it.
 `);
   /* eslint-enable max-len */
 };


### PR DESCRIPTION
## Summary

The `--force` flag is parsed and used by all three hierarchy operation CLI actions, but was missing from the `usage()` help text. This PR adds consistent documentation for the flag.

## Changes
- `src/fn/delete-contacts.js`: Added `--force` to usage OPTIONS
- `src/fn/move-contacts.js`: Added `--force` to usage OPTIONS  
- `src/fn/merge-contacts.js`: Added `--force` to usage OPTIONS

The `--force` flag controls whether the command prompts when the doc staging folder already contains files. When set, it continues using the existing folder without prompting.

## Related
This work supports understanding the CLI interface for hierarchy operations that DMP 2026 issue [medic/cht-core#10706](https://github.com/medic/cht-core/issues/10706) plans to port into `cht-core` as REST API endpoints.