### PR TITLE
Load api url for optional instance validations

### DIFF
--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -143,7 +143,16 @@ module.exports = async (argv, env) => {
   const projectName = fs.path.basename(pathToProject);
 
   const requiresInstance = actions.some(action => action.requiresInstance);
-  const apiUrl = requiresInstance && getApiUrl(cmdArgs, env);
+
+  let apiUrl;
+
+  try {
+    apiUrl = getApiUrl(cmdArgs, env);
+  } catch (err) {
+    if (requiresInstance) {
+      throw err;
+    }
+  }
 
   if (cmdArgs['accept-self-signed-certs'] || isLocalhost(apiUrl)) {
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;


### PR DESCRIPTION
# Description

This PR fixes an issue where `validate-*-forms` actions skipped validations that optionally require a CHT instance, even when a `--url` was provided.

Previously, `apiUrl` was only loaded when at least one action had `requiresInstance: true`. Since form validation actions set `requiresInstance: false`, validations depending on the API version were skipped unintentionally.

This change updates the logic to always attempt loading `apiUrl`, while only throwing an error if an action explicitly requires an instance.

medic/cht-conf#759

# Code review items

* [x] Readable: Concise, well named, follows the style guide
* [x] Tested: Existing validation flows tested manually
* [x] Backwards compatible: Offline validation behavior remains unchanged

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
