### PR TITLE
fix(#821): ignore deleted primary-contact ref in move-contacts

### DIFF
--- a/src/lib/hierarchy-operations/lineage-constraints.js
+++ b/src/lib/hierarchy-operations/lineage-constraints.js
@@ -166,7 +166,8 @@ async function assertSourcePrimaryContactType(db, contactTypeInfo, sourceDoc) {
     sourcePrimaryContactDoc = await db.get(sourcePrimaryContactId);
   } catch (err) {
     if (err.status === 404) {
-      log.warn(`Source "${sourceDoc._id}" has primary contact "${sourcePrimaryContactId}" which is deleted or missing. Ignoring.`);
+      log.warn(`Source "${sourceDoc._id}" has primary contact "${sourcePrimaryContactId}"` +
+        ` which is deleted or missing. Ignoring.`);
       return;
     }
     throw err;

--- a/src/lib/hierarchy-operations/lineage-constraints.js
+++ b/src/lib/hierarchy-operations/lineage-constraints.js
@@ -161,7 +161,17 @@ async function assertSourcePrimaryContactType(db, contactTypeInfo, sourceDoc) {
     return;
   }
 
-  const sourcePrimaryContactDoc = await db.get(sourcePrimaryContactId);
+  let sourcePrimaryContactDoc;
+  try {
+    sourcePrimaryContactDoc = await db.get(sourcePrimaryContactId);
+  } catch (err) {
+    if (err.status === 404) {
+      log.warn(`Source "${sourceDoc._id}" has primary contact "${sourcePrimaryContactId}" which is deleted or missing. Ignoring.`);
+      return;
+    }
+    throw err;
+  }
+
   const primaryContactIsPlace = isPlace(contactTypeInfo, sourcePrimaryContactDoc);
   if (primaryContactIsPlace) {
     throw new Error(`Source "${sourceDoc._id}" has primary contact "${sourcePrimaryContactId}" which is of type place`);

--- a/test/lib/hierarchy-operations/lineage-constraints.spec.js
+++ b/test/lib/hierarchy-operations/lineage-constraints.spec.js
@@ -207,10 +207,18 @@ describe('lineage constriants', () => {
     });
 
     it('no error when primary contact doc is deleted (404)', async () => {
+      const warnStub = sinon.stub(log, 'warn');
       const deletedErr = Object.assign(new Error('deleted'), { status: 404 });
       const mockDb = { get: sinon.stub().rejects(deletedErr) };
       const sourceDoc = { _id: 'place_1', type: 'health_center', contact: { _id: 'deleted_person' } };
-      await assertSourcePrimaryContactType(mockDb, {}, sourceDoc);
+      try {
+        await assertSourcePrimaryContactType(mockDb, {}, sourceDoc);
+        expect(warnStub.calledOnce).to.be.true;
+        expect(warnStub.firstCall.args[0]).to.include('place_1');
+        expect(warnStub.firstCall.args[0]).to.include('deleted_person');
+      } finally {
+        warnStub.restore();
+      }
     });
 
     it('rethrows non-404 errors', async () => {

--- a/test/lib/hierarchy-operations/lineage-constraints.spec.js
+++ b/test/lib/hierarchy-operations/lineage-constraints.spec.js
@@ -4,6 +4,7 @@ PouchDB.plugin(require('pouchdb-mapreduce'));
 const rewire = require('rewire');
 
 const { expect } = require('chai');
+const sinon = require('sinon');
 
 const { mockHierarchy } = require('../../mock-hierarchies');
 
@@ -192,6 +193,48 @@ describe('lineage constriants', () => {
         const doc = await assertOnPrimaryContactRemoval(pouchDb, contactDoc, parentDoc, [contactDoc]);
         expect(doc).to.be.undefined;
       });
+    });
+  });
+
+  describe('assertSourcePrimaryContactType', () => {
+    const assertSourcePrimaryContactType = lineageConstraints.__get__('assertSourcePrimaryContactType');
+
+    it('no error when sourceDoc has no primary contact', async () => {
+      const mockDb = { get: sinon.stub() };
+      const sourceDoc = { _id: 'place_1', type: 'health_center' };
+      await assertSourcePrimaryContactType(mockDb, {}, sourceDoc);
+      expect(mockDb.get.called).to.be.false;
+    });
+
+    it('no error when primary contact doc is deleted (404)', async () => {
+      const deletedErr = Object.assign(new Error('deleted'), { status: 404 });
+      const mockDb = { get: sinon.stub().rejects(deletedErr) };
+      const sourceDoc = { _id: 'place_1', type: 'health_center', contact: { _id: 'deleted_person' } };
+      await assertSourcePrimaryContactType(mockDb, {}, sourceDoc);
+    });
+
+    it('rethrows non-404 errors', async () => {
+      const serverErr = Object.assign(new Error('server_error'), { status: 500 });
+      const mockDb = { get: sinon.stub().rejects(serverErr) };
+      const sourceDoc = { _id: 'place_1', type: 'health_center', contact: { _id: 'some_person' } };
+      await expect(assertSourcePrimaryContactType(mockDb, {}, sourceDoc)).to.eventually.be.rejectedWith('server_error');
+    });
+
+    it('throws when primary contact is a place', async () => {
+      const placeDoc = { _id: 'place_2', type: 'clinic' };
+      const contactTypeInfo = { clinic: { parents: ['health_center'], person: false } };
+      const mockDb = { get: sinon.stub().resolves(placeDoc) };
+      const sourceDoc = { _id: 'place_1', type: 'health_center', contact: { _id: 'place_2' } };
+      await expect(assertSourcePrimaryContactType(mockDb, contactTypeInfo, sourceDoc))
+        .to.eventually.be.rejectedWith('which is of type place');
+    });
+
+    it('no error when primary contact is a person', async () => {
+      const personDoc = { _id: 'person_1', type: 'person' };
+      const contactTypeInfo = { person: { parents: ['health_center'], person: true } };
+      const mockDb = { get: sinon.stub().resolves(personDoc) };
+      const sourceDoc = { _id: 'place_1', type: 'health_center', contact: { _id: 'person_1' } };
+      await assertSourcePrimaryContactType(mockDb, contactTypeInfo, sourceDoc);
     });
   });
 });


### PR DESCRIPTION

# Description

Wrap the db.get(sourcePrimaryContactId) call in a try/catch. A 404 (deleted or missing doc) is treated as "no primary contact" — a WARN is logged and the operation continues. Any other error is re-thrown unchanged.

medic/cht-conf #821 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
