### PR TITLE
Load API URL for optional form validations

### DIFF
--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -145,7 +145,8 @@ module.exports = async (argv, env) => {
   const projectName = fs.path.basename(pathToProject);
 
   const requiresInstance = actions.some(action => action.requiresInstance);
-  const apiUrl = requiresInstance && getApiUrl(cmdArgs, env);
+  const instanceConfigProvided = cmdArgs.local || cmdArgs.instance || cmdArgs.url || cmdArgs.archive;
+  const apiUrl = (requiresInstance || instanceConfigProvided) && getApiUrl(cmdArgs, env);
 
   if (cmdArgs['accept-self-signed-certs'] || isLocalhost(apiUrl)) {
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;

--- a/test/lib/main.spec.js
+++ b/test/lib/main.spec.js
@@ -109,6 +109,24 @@ describe('main', () => {
     expect(mocks.usage.called).to.be.false;
   });
 
+  it('does not load api url for optional-instance actions without instance config', async () => {
+    await main([...normalArgv, 'validate-contact-forms'], {});
+    expect(mocks.getApiUrl.called).to.be.false;
+    expect(mocks.environment.initialize.args[0][4]).to.be.undefined;
+    expect(mocks.executeAction.callCount).to.deep.eq(1);
+    expect(mocks.executeAction.args[0][0].name).to.eq('validate-contact-forms');
+  });
+
+  it('loads api url for optional-instance actions when instance config is provided', async () => {
+    await main([...normalArgv, '--url=https://admin:pwd@example.com/', 'validate-contact-forms'], {});
+    expect(mocks.getApiUrl.calledOnce).to.be.true;
+    expect(mocks.getApiUrl.args[0][0].url).to.eq('https://admin:pwd@example.com/');
+    expect(mocks.environment.initialize.args[0][4]).to.eq('http://api');
+    expect(mocks.executeAction.callCount).to.deep.eq(1);
+    expect(mocks.executeAction.args[0][0].name).to.eq('validate-contact-forms');
+    expect(apiAvailable.called).to.be.false;
+  });
+
   const expectExecuteActionBehavior = (expectedActions, expectedExtraParams, expectRequireUrl = true) => {
     if (Array.isArray(expectedActions)) {
       expect(mocks.executeAction.args.map(args => args[0].name)).to.deep.eq(expectedActions);


### PR DESCRIPTION
## Summary

Fixes #759 by making the API URL available to optional instance-aware form validations when the user explicitly provides instance configuration.

The `validate-*-forms` actions keep `requiresInstance: false` because they can run fully offline. However, some individual validations can use the CHT instance when one is available, for example to load the CHT version and decide whether a deprecation warning applies. Before this change, running only `validate-*-forms` with `--url` still left `environment.apiUrl` unset, so those optional instance validations were skipped.

## Approach

This PR keeps the offline path unchanged and only resolves `apiUrl` when either:

- at least one selected action requires an instance; or
- the user explicitly supplied instance configuration with `--local`, `--instance`, `--url`, or `--archive`.

That means purely offline validation commands do not call `getApiUrl`, while commands such as `cht --url=... validate-contact-forms` now populate `environment.apiUrl` for optional validations. This also avoids swallowing invalid instance configuration: if the user provides instance options, `getApiUrl` is allowed to validate them normally.

The availability check remains gated by `requiresInstance`, so optional validations can receive `apiUrl` without making the whole action require a live instance.

## Testing

- `npx eslint src/lib/main.js test/lib/main.spec.js`
- `npx mocha test/lib/main.spec.js`
- `FORCE_COLOR=1 npm test` (`851 passing`, `1 pending`)

*This PR was developed by Codex with supervision from jmtdev0.*