### PR TITLE
fix(#830): backup-form should not crash if form has no attachments

### DIFF
--- a/src/fn/backup-all-forms.js
+++ b/src/fn/backup-all-forms.js
@@ -20,7 +20,7 @@ module.exports = {
       return db.get(form.id, { attachments: true, binary: true })
         .then(form => {
           fs.writeJson(`${backupDir}/context.json`, form.context);
-          Object.keys(form._attachments).forEach(name => {
+          Object.keys(form._attachments || {}).forEach(name => {
             const att = form._attachments[name];
             const destination = fs.path.join(backupDir, name);
             if (fs.path.dirname(destination) !== backupDir) {

--- a/test/fn/backup-all-forms.spec.js
+++ b/test/fn/backup-all-forms.spec.js
@@ -1,0 +1,61 @@
+const { expect } = require('chai');
+const path = require('path');
+const rewire = require('rewire');
+const sinon = require('sinon');
+
+describe('backup-all-forms', () => {
+  let backupAllForms;
+  let db;
+  let fsStub;
+
+  beforeEach(() => {
+    backupAllForms = rewire('../../src/fn/backup-all-forms');
+
+    db = { get: sinon.stub() };
+
+    fsStub = {
+      mkdir: sinon.stub(),
+      writeJson: sinon.stub(),
+      writeBinary: sinon.stub(),
+      path,
+    };
+
+    backupAllForms.__set__('pouch', () => db);
+    backupAllForms.__set__('backupFileFor', () => '/tmp/backups/forms.bak');
+    backupAllForms.__set__('fs', fsStub);
+    backupAllForms.__set__('log', () => {});
+    backupAllForms.__set__('environment', { pathToProject: '.' });
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('backs up attachments when present', async () => {
+    backupAllForms.__set__('formsList', () => Promise.resolve({ rows: [{ id: 'form:with-attachments' }] }));
+    db.get.resolves({
+      _id: 'form:with-attachments',
+      context: { person: true },
+      _attachments: {
+        'xml': { data: Buffer.from('<xml/>') },
+      },
+    });
+
+    await backupAllForms.execute();
+
+    expect(fsStub.writeBinary).to.have.been.calledOnce;
+    expect(fsStub.writeBinary.firstCall.args[0]).to.equal('/tmp/backups/forms.bak/form_with-attachments/xml');
+  });
+
+  it('#830 - does not throw when a form has no _attachments', async () => {
+    backupAllForms.__set__('formsList', () => Promise.resolve({ rows: [{ id: 'form:no-attachments' }] }));
+    db.get.resolves({ _id: 'form:no-attachments', context: { person: true } });
+
+    await backupAllForms.execute();
+
+    expect(fsStub.writeJson).to.have.been.calledOnceWithExactly(
+      '/tmp/backups/forms.bak/form_no-attachments/context.json',
+      { person: true },
+    );
+    expect(fsStub.writeBinary).to.not.have.been.called;
+  });
+
+});


### PR DESCRIPTION
# Description

Closes #830

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
