### PR TITLE
feat(#528): validate branding and partners configuration before upload

### DIFF
--- a/src/fn/upload-branding.js
+++ b/src/fn/upload-branding.js
@@ -1,5 +1,6 @@
 const environment = require('../lib/environment');
 const uploadConfigurationDocs = require('../lib/upload-configuration-docs');
+const { validateBranding } = require('../lib/validate-configuration-docs');
 
 module.exports = {
   requiresInstance: true,
@@ -7,6 +8,6 @@ module.exports = {
     const configurationPath = `${environment.pathToProject}/branding.json`;
     const directoryPath = `${environment.pathToProject}/branding`;
 
-    return uploadConfigurationDocs(configurationPath, directoryPath, 'branding');
+    return uploadConfigurationDocs(configurationPath, directoryPath, 'branding', undefined, validateBranding);
   }
 };

--- a/src/fn/upload-branding.js
+++ b/src/fn/upload-branding.js
@@ -8,6 +8,6 @@ module.exports = {
     const configurationPath = `${environment.pathToProject}/branding.json`;
     const directoryPath = `${environment.pathToProject}/branding`;
 
-    return uploadConfigurationDocs(configurationPath, directoryPath, 'branding', undefined, validateBranding);
+    return uploadConfigurationDocs(configurationPath, directoryPath, 'branding', { validate: validateBranding });
   }
 };

--- a/src/fn/upload-partners.js
+++ b/src/fn/upload-partners.js
@@ -8,6 +8,6 @@ module.exports = {
     const configurationPath = `${environment.pathToProject}/partners.json`;
     const directoryPath = `${environment.pathToProject}/partners`;
 
-    return uploadConfigurationDocs(configurationPath, directoryPath, 'partners', undefined, validatePartners);
+    return uploadConfigurationDocs(configurationPath, directoryPath, 'partners', { validate: validatePartners });
   }
 };

--- a/src/fn/upload-partners.js
+++ b/src/fn/upload-partners.js
@@ -1,5 +1,6 @@
 const environment = require('../lib/environment');
 const uploadConfigurationDocs = require('../lib/upload-configuration-docs');
+const { validatePartners } = require('../lib/validate-configuration-docs');
 
 module.exports = {
   requiresInstance: true,
@@ -7,6 +8,6 @@ module.exports = {
     const configurationPath = `${environment.pathToProject}/partners.json`;
     const directoryPath = `${environment.pathToProject}/partners`;
 
-    return uploadConfigurationDocs(configurationPath, directoryPath, 'partners');
+    return uploadConfigurationDocs(configurationPath, directoryPath, 'partners', undefined, validatePartners);
   }
 };

--- a/src/fn/upload-resources.js
+++ b/src/fn/upload-resources.js
@@ -16,7 +16,7 @@ module.exports = {
     const configurationPath = `${environment.pathToProject}/${RESOURCE_CONFIG_PATH}`;
     const directoryPath = `${environment.pathToProject}/${RESOURCES_DIR_PATH}`;
 
-    return uploadConfigurationDocs(configurationPath, directoryPath, 'resources', processJson);
+    return uploadConfigurationDocs(configurationPath, directoryPath, 'resources', { processJson });
   }
 };
 

--- a/src/lib/upload-configuration-docs.js
+++ b/src/lib/upload-configuration-docs.js
@@ -29,9 +29,11 @@ function filterAttachments(attachments, settings) {
  * @param dbDocName (Mandatory) String. DB's document name.
  * @param processJson (Optional) Function. Receives the content of configuration json and
  *        returns an object that is used for extending the DB's document.
+ * @param validate (Optional) Function. Receives the settings and the attachments and returns
+ *        `{ valid: boolean, error?: string }`. When invalid, nothing is uploaded and an error is thrown.
  * @return {Promise<void>}
  */
-module.exports = async (configPath, directoryPath, dbDocName, processJson) => {
+module.exports = async (configPath, directoryPath, dbDocName, processJson, validate) => {
   if (!configPath && !directoryPath && !dbDocName) {
     warn('Information missing: Make sure to provide the configuration file path and the directory path.');
     return Promise.resolve();
@@ -47,6 +49,13 @@ module.exports = async (configPath, directoryPath, dbDocName, processJson) => {
   const json = fs.readJson(jsonPath);
   const settings = processJson ? processJson(json) : json;
   const attachments = attachmentsFromDir(directoryPath);
+
+  if (validate) {
+    const validation = validate(settings, attachments);
+    if (!validation.valid) {
+      throw new Error(`Invalid ${dbDocName} configuration in ${jsonPath}: ${validation.error}`);
+    }
+  }
   const baseDocument = {
     _id: dbDocName,
     _attachments: filterAttachments(attachments, settings)

--- a/src/lib/upload-configuration-docs.js
+++ b/src/lib/upload-configuration-docs.js
@@ -22,7 +22,7 @@ function filterAttachments(attachments, settings) {
     }, {});
 }
 
-const assertValidConfiguration = (validate, settings, attachments, dbDocName, jsonPath) => {
+const assertValidConfiguration = (validate, settings, attachments, { dbDocName, jsonPath }) => {
   if (!validate) {
     return;
   }
@@ -76,7 +76,7 @@ async function uploadConfigurationDocs(configPath, directoryPath, dbDocName, opt
   const settings = processJson ? processJson(json) : json;
   const attachments = attachmentsFromDir(directoryPath);
 
-  assertValidConfiguration(validate, settings, attachments, dbDocName, jsonPath);
+  assertValidConfiguration(validate, settings, attachments, { dbDocName, jsonPath });
 
   const baseDocument = {
     _id: dbDocName,

--- a/src/lib/upload-configuration-docs.js
+++ b/src/lib/upload-configuration-docs.js
@@ -22,48 +22,17 @@ function filterAttachments(attachments, settings) {
     }, {});
 }
 
-/**
- * Upload Configuration to DB's document
- * @param configPath (Mandatory) String. Path to configuration json file.
- * @param directoryPath (Mandatory) String. Path to directory of attachments.
- * @param dbDocName (Mandatory) String. DB's document name.
- * @param processJson (Optional) Function. Receives the content of configuration json and
- *        returns an object that is used for extending the DB's document.
- * @param validate (Optional) Function. Receives the settings and the attachments and returns
- *        `{ valid: boolean, error?: string }`. When invalid, nothing is uploaded and an error is thrown.
- * @return {Promise<void>}
- */
-module.exports = async (configPath, directoryPath, dbDocName, processJson, validate) => {
-  if (!configPath && !directoryPath && !dbDocName) {
-    warn('Information missing: Make sure to provide the configuration file path and the directory path.');
-    return Promise.resolve();
+const assertValidConfiguration = (validate, settings, attachments, dbDocName, jsonPath) => {
+  if (!validate) {
+    return;
   }
-
-  const jsonPath = fs.path.resolve(configPath);
-
-  if (!fs.exists(jsonPath)) {
-    warn(`No configuration file found at path: ${jsonPath}`);
-    return Promise.resolve();
+  const validation = validate(settings, attachments);
+  if (!validation.valid) {
+    throw new Error(`Invalid ${dbDocName} configuration in ${jsonPath}: ${validation.error}`);
   }
+};
 
-  const json = fs.readJson(jsonPath);
-  const settings = processJson ? processJson(json) : json;
-  const attachments = attachmentsFromDir(directoryPath);
-
-  if (validate) {
-    const validation = validate(settings, attachments);
-    if (!validation.valid) {
-      throw new Error(`Invalid ${dbDocName} configuration in ${jsonPath}: ${validation.error}`);
-    }
-  }
-  const baseDocument = {
-    _id: dbDocName,
-    _attachments: filterAttachments(attachments, settings)
-  };
-  const doc = Object.assign({}, baseDocument, settings);
-
-  const db = pouch();
-
+const uploadDoc = async (db, doc) => {
   const changes = await warnUploadOverwrite.preUploadDoc(db, doc);
 
   if (changes) {
@@ -74,6 +43,48 @@ module.exports = async (configPath, directoryPath, dbDocName, processJson, valid
   }
 
   await warnUploadOverwrite.postUploadDoc(db, doc);
-
-  return Promise.resolve();
 };
+
+/**
+ * Upload Configuration to DB's document
+ * @param configPath (Mandatory) String. Path to configuration json file.
+ * @param directoryPath (Mandatory) String. Path to directory of attachments.
+ * @param dbDocName (Mandatory) String. DB's document name.
+ * @param options (Optional) Object.
+ * @param options.processJson (Optional) Function. Receives the content of configuration json and
+ *        returns an object that is used for extending the DB's document.
+ * @param options.validate (Optional) Function. Receives the settings and the attachments and returns
+ *        `{ valid: boolean, error?: string }`. When invalid, nothing is uploaded and an error is thrown.
+ * @return {Promise<void>}
+ */
+async function uploadConfigurationDocs(configPath, directoryPath, dbDocName, options = {}) {
+  const { processJson, validate } = options;
+
+  if (!configPath && !directoryPath && !dbDocName) {
+    warn('Information missing: Make sure to provide the configuration file path and the directory path.');
+    return;
+  }
+
+  const jsonPath = fs.path.resolve(configPath);
+
+  if (!fs.exists(jsonPath)) {
+    warn(`No configuration file found at path: ${jsonPath}`);
+    return;
+  }
+
+  const json = fs.readJson(jsonPath);
+  const settings = processJson ? processJson(json) : json;
+  const attachments = attachmentsFromDir(directoryPath);
+
+  assertValidConfiguration(validate, settings, attachments, dbDocName, jsonPath);
+
+  const baseDocument = {
+    _id: dbDocName,
+    _attachments: filterAttachments(attachments, settings)
+  };
+  const doc = Object.assign({}, baseDocument, settings);
+
+  await uploadDoc(pouch(), doc);
+}
+
+module.exports = uploadConfigurationDocs;

--- a/src/lib/validate-configuration-docs.js
+++ b/src/lib/validate-configuration-docs.js
@@ -1,0 +1,62 @@
+const joi = require('joi');
+
+// Structure expected by cht-core (api/src/services/branding.js, admin images-branding controller):
+// `title` is required and `resources` maps a fixed set of keys to attachment names.
+const BrandingSchema = joi.object({
+  title: joi.string().min(1).required(),
+  resources: joi.object({
+    logo: joi.string().min(1),
+    favicon: joi.string().min(1),
+    icon: joi.string().min(1),
+  }),
+});
+
+// Structure expected by cht-core (admin images-partners controller, about page):
+// `resources` maps a partner name to an attachment name.
+const PartnersSchema = joi.object({
+  resources: joi.object()
+    .pattern(joi.string().min(1), joi.string().min(1))
+    .required(),
+});
+
+const validateSchema = (schema, config) => {
+  const { error } = schema.validate(config, { abortEarly: false });
+  return error ? error.details.map(detail => detail.message) : [];
+};
+
+// Every `resources` value must reference a file that exists in the attachments directory,
+// otherwise cht-core will look up an attachment that was never uploaded.
+const findMissingAttachments = (config, attachments) => {
+  const resources = config && config.resources;
+  if (!resources || typeof resources !== 'object') {
+    return [];
+  }
+  return Object
+    .entries(resources)
+    .filter(([, fileName]) => !attachments || !attachments[fileName])
+    .map(([key, fileName]) => `"resources.${key}" references "${fileName}" but no such file was found`);
+};
+
+const validate = (schema, config, attachments) => {
+  const errors = validateSchema(schema, config);
+  if (!errors.length) {
+    errors.push(...findMissingAttachments(config, attachments));
+  }
+  return errors.length ? { valid: false, error: errors.join('; ') } : { valid: true };
+};
+
+module.exports = {
+  /**
+   * @param {object} config content of branding.json
+   * @param {object} attachments attachments built from the branding/ directory (file name -> attachment)
+   * @return {{valid: boolean, error?: string}}
+   */
+  validateBranding: (config, attachments) => validate(BrandingSchema, config, attachments),
+
+  /**
+   * @param {object} config content of partners.json
+   * @param {object} attachments attachments built from the partners/ directory (file name -> attachment)
+   * @return {{valid: boolean, error?: string}}
+   */
+  validatePartners: (config, attachments) => validate(PartnersSchema, config, attachments),
+};

--- a/src/lib/validate-configuration-docs.js
+++ b/src/lib/validate-configuration-docs.js
@@ -27,13 +27,13 @@ const validateSchema = (schema, config) => {
 // Every `resources` value must reference a file that exists in the attachments directory,
 // otherwise cht-core will look up an attachment that was never uploaded.
 const findMissingAttachments = (config, attachments) => {
-  const resources = config && config.resources;
+  const resources = config?.resources;
   if (!resources || typeof resources !== 'object') {
     return [];
   }
   return Object
     .entries(resources)
-    .filter(([, fileName]) => !attachments || !attachments[fileName])
+    .filter(([, fileName]) => !attachments?.[fileName])
     .map(([key, fileName]) => `"resources.${key}" references "${fileName}" but no such file was found`);
 };
 

--- a/test/fn/upload-branding.spec.js
+++ b/test/fn/upload-branding.spec.js
@@ -23,8 +23,7 @@ describe('Upload Branding', () => {
       expect(uploadConfigurationDocs.args[0][0]).to.equal(configurationPath);
       expect(uploadConfigurationDocs.args[0][1]).to.equal(directoryPath);
       expect(uploadConfigurationDocs.args[0][2]).to.equal(dbDocName);
-      expect(uploadConfigurationDocs.args[0][3]).to.be.undefined;
-      expect(uploadConfigurationDocs.args[0][4]).to.equal(validateBranding);
+      expect(uploadConfigurationDocs.args[0][3]).to.deep.equal({ validate: validateBranding });
     });
   });
 });

--- a/test/fn/upload-branding.spec.js
+++ b/test/fn/upload-branding.spec.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const environment = require('../../src/lib/environment');
+const { validateBranding } = require('../../src/lib/validate-configuration-docs');
 const uploadBranding = rewire('../../src/fn/upload-branding');
 
 describe('Upload Branding', () => {
@@ -22,6 +23,8 @@ describe('Upload Branding', () => {
       expect(uploadConfigurationDocs.args[0][0]).to.equal(configurationPath);
       expect(uploadConfigurationDocs.args[0][1]).to.equal(directoryPath);
       expect(uploadConfigurationDocs.args[0][2]).to.equal(dbDocName);
+      expect(uploadConfigurationDocs.args[0][3]).to.be.undefined;
+      expect(uploadConfigurationDocs.args[0][4]).to.equal(validateBranding);
     });
   });
 });

--- a/test/fn/upload-partners.spec.js
+++ b/test/fn/upload-partners.spec.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const environment = require('../../src/lib/environment');
+const { validatePartners } = require('../../src/lib/validate-configuration-docs');
 const uploadPartners = rewire('../../src/fn/upload-partners');
 
 describe('Upload Partners', () => {
@@ -22,6 +23,8 @@ describe('Upload Partners', () => {
       expect(uploadConfigurationDocs.args[0][0]).to.equal(configurationPath);
       expect(uploadConfigurationDocs.args[0][1]).to.equal(directoryPath);
       expect(uploadConfigurationDocs.args[0][2]).to.equal(dbDocName);
+      expect(uploadConfigurationDocs.args[0][3]).to.be.undefined;
+      expect(uploadConfigurationDocs.args[0][4]).to.equal(validatePartners);
     });
   });
 });

--- a/test/fn/upload-partners.spec.js
+++ b/test/fn/upload-partners.spec.js
@@ -23,8 +23,7 @@ describe('Upload Partners', () => {
       expect(uploadConfigurationDocs.args[0][0]).to.equal(configurationPath);
       expect(uploadConfigurationDocs.args[0][1]).to.equal(directoryPath);
       expect(uploadConfigurationDocs.args[0][2]).to.equal(dbDocName);
-      expect(uploadConfigurationDocs.args[0][3]).to.be.undefined;
-      expect(uploadConfigurationDocs.args[0][4]).to.equal(validatePartners);
+      expect(uploadConfigurationDocs.args[0][3]).to.deep.equal({ validate: validatePartners });
     });
   });
 });

--- a/test/lib/upload-configuration-docs.spec.js
+++ b/test/lib/upload-configuration-docs.spec.js
@@ -103,7 +103,9 @@ describe('Upload Configuration Docs', () => {
     };
 
     return uploadConfigurationDocs.__with__(rewireWith)(async () => {
-      await uploadConfigurationDocs('path/configuration.json', 'path/configuration', 'configurationDoc', processJson);
+      await uploadConfigurationDocs(
+        'path/configuration.json', 'path/configuration', 'configurationDoc', { processJson }
+      );
 
       expect(attachmentsFromDir.called).to.be.true;
       expect(pouch.called).to.be.true;
@@ -128,7 +130,7 @@ describe('Upload Configuration Docs', () => {
 
     return uploadConfigurationDocs.__with__(rewireWith)(async () => {
       await uploadConfigurationDocs(
-        'path/configuration.json', 'path/configuration', 'configurationDoc', undefined, validate
+        'path/configuration.json', 'path/configuration', 'configurationDoc', { validate }
       );
 
       expect(validate.calledOnce).to.be.true;
@@ -153,7 +155,7 @@ describe('Upload Configuration Docs', () => {
 
     return uploadConfigurationDocs.__with__(rewireWith)(async () => {
       await expect(uploadConfigurationDocs(
-        'path/configuration.json', 'path/configuration', 'configurationDoc', undefined, validate
+        'path/configuration.json', 'path/configuration', 'configurationDoc', { validate }
       )).to.be.rejectedWith('Invalid configurationDoc configuration in path/configuration.json: "title" is required');
 
       expect(pouch.called).to.be.false;

--- a/test/lib/upload-configuration-docs.spec.js
+++ b/test/lib/upload-configuration-docs.spec.js
@@ -113,6 +113,55 @@ describe('Upload Configuration Docs', () => {
     });
   });
 
+  it('should upload when validate accepts the configuration', async () => {
+    warnUploadOverwrite.preUploadDoc.returns(true);
+    insertOrReplace.returns(Promise.resolve());
+    attachmentsFromDir.returns({ 'greatCompany.png': {} });
+    const validate = sinon.stub().returns({ valid: true });
+    const rewireWith = {
+      fs,
+      pouch,
+      attachmentsFromDir,
+      warnUploadOverwrite,
+      insertOrReplace
+    };
+
+    return uploadConfigurationDocs.__with__(rewireWith)(async () => {
+      await uploadConfigurationDocs(
+        'path/configuration.json', 'path/configuration', 'configurationDoc', undefined, validate
+      );
+
+      expect(validate.calledOnce).to.be.true;
+      expect(validate.args[0][0]).to.deep.equal(configuration);
+      expect(validate.args[0][1]).to.deep.equal({ 'greatCompany.png': {} });
+      expect(insertOrReplace.called).to.be.true;
+    });
+  });
+
+  it('should throw and not upload when validate rejects the configuration', async () => {
+    warnUploadOverwrite.preUploadDoc.returns(true);
+    insertOrReplace.returns(Promise.resolve());
+    attachmentsFromDir.returns({ 'greatCompany.png': {} });
+    const validate = sinon.stub().returns({ valid: false, error: '"title" is required' });
+    const rewireWith = {
+      fs,
+      pouch,
+      attachmentsFromDir,
+      warnUploadOverwrite,
+      insertOrReplace
+    };
+
+    return uploadConfigurationDocs.__with__(rewireWith)(async () => {
+      await expect(uploadConfigurationDocs(
+        'path/configuration.json', 'path/configuration', 'configurationDoc', undefined, validate
+      )).to.be.rejectedWith('Invalid configurationDoc configuration in path/configuration.json: "title" is required');
+
+      expect(pouch.called).to.be.false;
+      expect(warnUploadOverwrite.preUploadDoc.called).to.be.false;
+      expect(insertOrReplace.called).to.be.false;
+    });
+  });
+
   it('should warn when paths no provided', async () => {
     fs.exists = () => false;
     const rewireWith = {

--- a/test/lib/validate-configuration-docs.spec.js
+++ b/test/lib/validate-configuration-docs.spec.js
@@ -1,0 +1,110 @@
+const { expect } = require('chai');
+const { validateBranding, validatePartners } = require('../../src/lib/validate-configuration-docs');
+
+describe('validate-configuration-docs', () => {
+  describe('validateBranding', () => {
+    const attachments = { 'logo.png': {}, 'favicon.ico': {}, 'icon.svg': {} };
+
+    it('should accept a valid branding config', () => {
+      const config = {
+        title: 'My App',
+        resources: { logo: 'logo.png', favicon: 'favicon.ico', icon: 'icon.svg' },
+      };
+      expect(validateBranding(config, attachments)).to.deep.equal({ valid: true });
+    });
+
+    it('should accept a branding config with only a title', () => {
+      expect(validateBranding({ title: 'My App' }, {})).to.deep.equal({ valid: true });
+    });
+
+    it('should reject a missing title', () => {
+      const result = validateBranding({ resources: { logo: 'logo.png' } }, attachments);
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('"title" is required');
+    });
+
+    it('should reject a non-string title', () => {
+      const result = validateBranding({ title: 42 }, attachments);
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('"title" must be a string');
+    });
+
+    it('should reject resources that are not an object', () => {
+      const result = validateBranding({ title: 'My App', resources: 'logo.png' }, attachments);
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('"resources" must be of type object');
+    });
+
+    it('should reject unknown resource keys and non-string values', () => {
+      const result = validateBranding({ title: 'My App', resources: { logo: 1, banner: 'x.png' } }, attachments);
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('"resources.logo" must be a string');
+      expect(result.error).to.include('"resources.banner" is not allowed');
+    });
+
+    it('should reject resources that reference files missing from the directory', () => {
+      const config = { title: 'My App', resources: { logo: 'logo.png', favicon: 'missing.ico' } };
+      const result = validateBranding(config, { 'logo.png': {} });
+      expect(result.valid).to.be.false;
+      expect(result.error).to.equal('"resources.favicon" references "missing.ico" but no such file was found');
+    });
+
+    it('should report missing files when there are no attachments at all', () => {
+      const result = validateBranding({ title: 'My App', resources: { logo: 'logo.png' } }, undefined);
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('"resources.logo" references "logo.png"');
+    });
+  });
+
+  describe('validatePartners', () => {
+    const attachments = { 'partnerA.png': {}, 'partnerB.png': {} };
+
+    it('should accept a valid partners config', () => {
+      const config = { resources: { partnerA: 'partnerA.png', partnerB: 'partnerB.png' } };
+      expect(validatePartners(config, attachments)).to.deep.equal({ valid: true });
+    });
+
+    it('should accept an empty resources object', () => {
+      expect(validatePartners({ resources: {} }, {})).to.deep.equal({ valid: true });
+    });
+
+    it('should reject a missing resources object', () => {
+      const result = validatePartners({}, attachments);
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('"resources" is required');
+    });
+
+    it('should reject resources that are not an object', () => {
+      const result = validatePartners({ resources: ['partnerA.png'] }, attachments);
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('"resources" must be of type object');
+    });
+
+    it('should reject non-string resource values', () => {
+      const result = validatePartners({ resources: { partnerA: { file: 'partnerA.png' } } }, attachments);
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('"resources.partnerA" must be a string');
+    });
+
+    it('should reject unknown top-level keys', () => {
+      const result = validatePartners({ resources: {}, title: 'Partners' }, attachments);
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('"title" is not allowed');
+    });
+
+    it('should reject resources that reference files missing from the directory', () => {
+      const config = { resources: { partnerA: 'partnerA.png', partnerC: 'partnerC.png' } };
+      const result = validatePartners(config, attachments);
+      expect(result.valid).to.be.false;
+      expect(result.error).to.equal('"resources.partnerC" references "partnerC.png" but no such file was found');
+    });
+
+    it('should list every missing file', () => {
+      const config = { resources: { partnerA: 'a.png', partnerB: 'b.png' } };
+      const result = validatePartners(config, {});
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('"resources.partnerA" references "a.png"');
+      expect(result.error).to.include('"resources.partnerB" references "b.png"');
+    });
+  });
+});


### PR DESCRIPTION
# Description

`upload-branding` and `upload-partners` currently accept whatever is in `branding.json` / `partners.json` and upload it verbatim as the `branding` / `partners` doc. cht-core assumes a specific structure for these docs (`api/src/services/branding.js`, the admin `images-branding` / `images-partners` controllers): a string `title`, and a `resources` object whose values are attachment names. A malformed doc breaks the admin images pages without any indication of the cause (see the issue).

This PR validates both configuration files before anything is uploaded:

- **Schema validation** (joi, same approach as `validate-app-settings.js`):
  - `branding.json`: `title` is a required non-empty string; `resources` (optional) is an object whose `logo` / `favicon` / `icon` values are non-empty strings — the three keys cht-core reads.
  - `partners.json`: `resources` is a required object mapping partner name → non-empty string.
- **Attachment check**: every `resources` value must reference a file that exists in the `branding/` or `partners/` directory, otherwise cht-core would look up an attachment that was never uploaded.

On failure the action throws a descriptive error and nothing is written, e.g.

```
Invalid branding configuration in /project/branding.json: "title" must be a string; "resources" must be of type object
Invalid branding configuration in /project/branding.json: "resources.favicon" references "fav.ico" but no such file was found
Invalid partners configuration in /project/partners.json: "resources" must be of type object
```

Implementation: new `src/lib/validate-configuration-docs.js`; `upload-configuration-docs` takes an optional `validate(settings, attachments)` callback (alongside the existing optional `processJson`), and the two actions pass their validator. Other callers of `upload-configuration-docs` are unaffected.

medic/cht-conf#528

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: The accepted structure is already what [cht-docs describes](https://docs.communityhealthtoolkit.org/building/branding/application-graphics/); happy to add a note about the new validation errors there if you'd like.
- Tested: 17 new unit tests in `test/lib/validate-configuration-docs.spec.js` plus new cases in `test/lib/upload-configuration-docs.spec.js` (validate accepted / rejected → throws, no upload); action specs assert the validator is wired in.

# Verification

- Reproduced on `main` with the upload module stubbed: `{ "title": 42, "resources": "logo.png" }` is uploaded as-is. After this change the same input throws the first error above and `insertOrReplace` is never called; a valid config still uploads the same doc as before.
- `npm run eslint` clean.
- `npm test` in a clean `node:22` container with `FORCE_COLOR=1` (same as CI): **899 passing, 1 pending** (the pending one is pre-existing), 0 failing.

Written with assistance from Claude Code; every change and test result above was run and checked locally.